### PR TITLE
Update dependencies and improve README for model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ WhisperX supports these model sizes:
 - `base`, `base.en`
 - `small`, `small.en`
 - `medium`, `medium.en`
-- `large`, `large-v1`, `large-v2`, `large-v3`
-
-Note: `large-v3-turbo` is not yet supported by WhisperX.
+- `large`, `large-v1`, `large-v2`, `large-v3`, `large-v3-turbo`
 
 Set default model in `.env` using `WHISPER_MODEL=` (default: tiny)
 
@@ -184,10 +182,6 @@ The models used by whisperX are stored in `root/.cache`, if you want to avoid do
 1. **ctranslate2 Compatibility**
 
 - Only `ctranslate2==4.4.0` is supported due to CUDA compatibility issues with CTranslate2, as newer versions have different CUDA requirements <https://github.com/SYSTRAN/faster-whisper/issues/1086>.
-
-2. **faster-whisper Compatibility**
-
-- Only `faster-whisper==1.0.0` is supported due to compatibility issues with WhisperX.
 
 ## Troubleshooting
 

--- a/dockerfile
+++ b/dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.4.1-base-ubuntu22.04
+FROM nvidia/cuda:12.6.3-base-ubuntu22.04
 
 ENV PYTHON_VERSION=3.11
 

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -5,7 +5,7 @@ gunicorn==23.0.0
 httpx==0.28.1
 numba==0.60.0
 
-pytest==8.3.3
+pytest==8.3.4
 python-dotenv==1.0.1
 python-multipart==0.0.20
 tqdm==4.67.1

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -2,7 +2,7 @@ colorlog==6.9.0
 # ctranslate2==4.4.0
 fastapi==0.115.6
 gunicorn==23.0.0
-httpx==0.28.0
+httpx==0.28.1
 numba==0.60.0
 
 pytest==8.3.3

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -10,5 +10,5 @@ python-dotenv==1.0.1
 python-multipart==0.0.20
 tqdm==4.67.1
 # unidecode==1.3.8
-uvicorn==0.32.1
+uvicorn==0.34.0
 whisperx==3.3.0


### PR DESCRIPTION
Upgrade pytest to version 8.3.4 and nvidia/cuda to version 12.6.3. Update the README to reflect support for the 'large-v3-turbo' model and remove outdated compatibility notes.