### PR TITLE
Update ctranslate2 to version 4.6.0 for compatibility with libcudnn9-cuda-12

### DIFF
--- a/.devcontainer/post-attach.sh
+++ b/.devcontainer/post-attach.sh
@@ -3,3 +3,5 @@
 
 # Install dependencies to make sure the env is up to date
 uv pip install --system -r requirements/dev.txt
+# Install ctranslate2 to maintain compatibility with libcudnn9-cuda-12
+uv pip install ctranslate2==4.6.0 --system

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -9,6 +9,9 @@ which uv
 
 uv pip install --system -r requirements/dev.txt
 
+# Install ctranslate2 to maintain compatibility with libcudnn9-cuda-12
+uv pip install ctranslate2==4.6.0 --system
+
 git init
 pre-commit install
 

--- a/dockerfile
+++ b/dockerfile
@@ -29,10 +29,10 @@ COPY app/gunicorn_logging.conf .
 COPY requirements requirements/
 
 # Install Python dependencies using UV
-RUN uv pip install --system --no-cache-dir -r requirements/system.txt -i https://download.pytorch.org/whl/cu126 \
+RUN pip install --upgrade pip setuptools && uv pip install --system --no-cache-dir -r requirements/system.txt -i https://download.pytorch.org/whl/cu126 \
     && uv pip install --system --no-cache-dir -r requirements/prod.txt \
-    # Force install ctranslate2 version 4.5.0 or higher to maintain compatibility with libcudnn9-cuda-12
-    && uv pip install ctranslate2>=4.5.0 --system \
+    # Force install ctranslate2 version 4.6.0 or higher to maintain compatibility with libcudnn9-cuda-12
+    && uv pip install ctranslate2==4.6.0 --system \
     # Clean pip cache and temporary files
     && rm -rf /root/.cache /tmp/*
 


### PR DESCRIPTION
Ensure ctranslate2 version 4.6.0 is installed to maintain compatibility with libcudnn9-cuda-12 across the environment.