### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -49,7 +49,7 @@ jobs:
           echo "event type is:" ${{ github.event.action }}
           echo "actor is:" ${{ github.actor }}
       - name: Cache and install ffmpeg
-        uses: awalsh128/cache-apt-pkgs-action@v1.3.4
+        uses: awalsh128/cache-apt-pkgs-action@latest
         with:
           packages: ffmpeg
           version: 1.0

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,10 +48,10 @@ jobs:
           echo "event name is:" ${{ github.event_name }}
           echo "event type is:" ${{ github.event.action }}
           echo "actor is:" ${{ github.actor }}
-      - name: Cache and install ffmpeg
+      - name: Cache and install ffmpeg and libblas3
         uses: awalsh128/cache-apt-pkgs-action@latest
         with:
-          packages: ffmpeg
+          packages: ffmpeg libblas3
           version: 1.0
       - name: Install uv
         uses: astral-sh/setup-uv@v6

--- a/app/main.py
+++ b/app/main.py
@@ -7,11 +7,10 @@ filter_warnings()
 import time  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 
-logging.basicConfig(level=logging.INFO)  # Basic logging configuration
-
 from dotenv import load_dotenv  # noqa: E402
 from fastapi import FastAPI, status  # noqa: E402
-import logging  # Added for logging exceptions
+import logging  # noqa: E402
+
 from fastapi.responses import JSONResponse, RedirectResponse  # noqa: E402
 from sqlalchemy import text  # noqa: E402
 
@@ -25,6 +24,8 @@ from .routers import stt, stt_services, task  # noqa: E402
 load_dotenv()
 
 Base.metadata.create_all(bind=engine)
+
+logging.basicConfig(level=logging.INFO)  # Basic logging configuration
 
 
 @asynccontextmanager
@@ -157,13 +158,14 @@ async def readiness_check():
                 "message": "Application is ready to accept requests",
             },
         )
-    except Exception as e:
-        logging.exception("Readiness check failed:")
+    except Exception:
+        logging.exception("Readiness check failed:")
+
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             content={
                 "status": "error",
                 "database": "disconnected",
-                "message": "Application is not ready due to an internal error.",
+                "message": "Application is not ready due to an internal error.",
             },
         )

--- a/app/main.py
+++ b/app/main.py
@@ -7,8 +7,11 @@ filter_warnings()
 import time  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 
+logging.basicConfig(level=logging.INFO)  # Basic logging configuration
+
 from dotenv import load_dotenv  # noqa: E402
 from fastapi import FastAPI, status  # noqa: E402
+import logging  # Added for logging exceptions
 from fastapi.responses import JSONResponse, RedirectResponse  # noqa: E402
 from sqlalchemy import text  # noqa: E402
 
@@ -155,11 +158,12 @@ async def readiness_check():
             },
         )
     except Exception as e:
+        logging.exception("Readiness check failed:")
         return JSONResponse(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             content={
                 "status": "error",
                 "database": "disconnected",
-                "message": f"Application is not ready: {str(e)}",
+                "message": "Application is not ready due to an internal error.",
             },
         )

--- a/app/main.py
+++ b/app/main.py
@@ -25,8 +25,6 @@ load_dotenv()
 
 Base.metadata.create_all(bind=engine)
 
-logging.basicConfig(level=logging.INFO)  # Basic logging configuration
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -99,7 +99,7 @@ def test_readiness_check_with_db_failure(monkeypatch):
         data = response.json()
         assert data["status"] == "error"
         assert data["database"] == "disconnected"
-        assert "Database connection failed" in data["message"]
+        assert data["message"] == "Application is not ready due to an internal error."
     finally:
         # Restore the original connect method
         monkeypatch.setattr(engine, "connect", original_connect)


### PR DESCRIPTION
Potential fix for [https://github.com/pavelzbornik/whisperX-FastAPI/security/code-scanning/3](https://github.com/pavelzbornik/whisperX-FastAPI/security/code-scanning/3)

To fix the problem, we should avoid returning the exception message (`str(e)`) to the user in the JSON response. Instead, we should log the exception internally (for example, using Python's `logging` module) and return a generic error message such as "Application is not ready due to an internal error." This change should be made in the exception handler of the `readiness_check` function (lines 157-165 in `app/main.py`). We will also need to import the `logging` module and configure it if not already done.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
