### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/gitleaks.yaml
+++ b/.github/workflows/gitleaks.yaml
@@ -3,6 +3,8 @@
 # You should have received a copy of the GITLEAKS-ACTION END-USER LICENSE AGREEMENT with this file.
 # If not, please visit https://gitleaks.io/COMMERCIAL-LICENSE.txt.
 name: gitleaks
+permissions:
+  contents: read
 concurrency:
   group: gitleaks-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/pavelzbornik/whisperX-FastAPI/security/code-scanning/1](https://github.com/pavelzbornik/whisperX-FastAPI/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. Since the workflow only has one job, you can add the block at either the root level (applies to all jobs) or at the job level (applies only to the `scan` job). The minimal required permission for this workflow is `contents: read`, which allows the job to read repository contents but not write to them. This should be added above the `jobs:` key (for workflow-level) or inside the `scan:` job (for job-level). The best practice is to add it at the workflow level unless you have jobs with different permission requirements.

No additional methods, imports, or definitions are needed; just add the `permissions` block in the YAML file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
