### PR TITLE
Update CI permissions and artifact path in workflows

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -40,7 +40,7 @@ jobs:
     needs: [lint]
     timeout-minutes: 30
     permissions:
-      contents: read
+      contents: write
       # Only escalate to write for version bump step
     steps:
       - name: Checkout code

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -79,4 +79,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: coverage-html
-          path: htmlcov/index.html
+          path: htmlcov/


### PR DESCRIPTION
Adjust CI permissions to allow write access for the build-and-test job and modify the artifact path in the lint workflow to include the entire coverage directory.