### PR TITLE
fix(api): accept wrapped task envelope in /service/align (#525)

### DIFF
--- a/app/api/audio_services_api.py
+++ b/app/api/audio_services_api.py
@@ -78,13 +78,13 @@ def _parse_transcript_payload(payload: bytes) -> Transcript:
     """
     try:
         data = json.loads(payload)
-    except json.JSONDecodeError as e:
+    except (json.JSONDecodeError, UnicodeDecodeError) as e:
         logger.error("Transcript file is not valid JSON: %s", str(e))
         raise ValidationError(
-            message=f"Transcript file is not valid JSON: {str(e)}",
+            message=f"Transcript file is not valid JSON: {e!s}",
             code="INVALID_TRANSCRIPT_JSON",
             user_message="The transcript file contains invalid JSON.",
-        )
+        ) from e
 
     # Auto-unwrap the GET /task/{id} envelope when the user uploads it as-is.
     if (
@@ -99,10 +99,10 @@ def _parse_transcript_payload(payload: bytes) -> Transcript:
     except (PydanticValidationError, TypeError) as e:
         logger.error("Invalid JSON content in transcript file: %s", str(e))
         raise ValidationError(
-            message=f"Invalid JSON content in transcript file: {str(e)}",
+            message=f"Invalid JSON content in transcript file: {e!s}",
             code="INVALID_TRANSCRIPT_JSON",
             user_message="The transcript file contains invalid JSON.",
-        )
+        ) from e
 
 
 @service_router.post(
@@ -230,7 +230,7 @@ async def align(
 
     file_service.validate_file_extension(transcript.filename, {JSON_EXTENSION})
 
-    transcript_data = _parse_transcript_payload(transcript.file.read())
+    transcript_data = _parse_transcript_payload(await transcript.read())
 
     # Validate and save audio file
     if file.filename is None:

--- a/app/api/audio_services_api.py
+++ b/app/api/audio_services_api.py
@@ -68,6 +68,43 @@ from app.transcript import filter_aligned_transcription
 service_router = APIRouter()
 
 
+def _parse_transcript_payload(payload: bytes) -> Transcript:
+    """Parse an uploaded transcript JSON payload.
+
+    Accepts either the bare ``Transcript`` shape (``{segments, language}``)
+    or the wrapped envelope returned by ``GET /task/{identifier}``
+    (``{status, result, metadata, error}``) — in the latter case the inner
+    ``result`` is unwrapped before validation.
+    """
+    try:
+        data = json.loads(payload)
+    except json.JSONDecodeError as e:
+        logger.error("Transcript file is not valid JSON: %s", str(e))
+        raise ValidationError(
+            message=f"Transcript file is not valid JSON: {str(e)}",
+            code="INVALID_TRANSCRIPT_JSON",
+            user_message="The transcript file contains invalid JSON.",
+        )
+
+    # Auto-unwrap the GET /task/{id} envelope when the user uploads it as-is.
+    if (
+        isinstance(data, dict)
+        and "segments" not in data
+        and isinstance(data.get("result"), dict)
+    ):
+        data = data["result"]
+
+    try:
+        return Transcript(**data)
+    except (PydanticValidationError, TypeError) as e:
+        logger.error("Invalid JSON content in transcript file: %s", str(e))
+        raise ValidationError(
+            message=f"Invalid JSON content in transcript file: {str(e)}",
+            code="INVALID_TRANSCRIPT_JSON",
+            user_message="The transcript file contains invalid JSON.",
+        )
+
+
 @service_router.post(
     "/service/transcribe",
     tags=["Speech-2-Text services"],
@@ -193,16 +230,7 @@ async def align(
 
     file_service.validate_file_extension(transcript.filename, {JSON_EXTENSION})
 
-    try:
-        # Read the content of the transcript file
-        transcript_data = Transcript(**json.loads(transcript.file.read()))
-    except PydanticValidationError as e:
-        logger.error("Invalid JSON content in transcript file: %s", str(e))
-        raise ValidationError(
-            message=f"Invalid JSON content in transcript file: {str(e)}",
-            code="INVALID_TRANSCRIPT_JSON",
-            user_message="The transcript file contains invalid JSON.",
-        )
+    transcript_data = _parse_transcript_payload(transcript.file.read())
 
     # Validate and save audio file
     if file.filename is None:

--- a/tests/e2e/test_audio_processing_endpoints.py
+++ b/tests/e2e/test_audio_processing_endpoints.py
@@ -268,6 +268,57 @@ def test_align_service(client: TestClient) -> None:
 
 
 @pytest.mark.e2e
+def test_align_service_accepts_wrapped_task_result(client: TestClient) -> None:
+    """Regression for issue #525.
+
+    The JSON file users download from ``GET /task/{identifier}`` is wrapped in
+    a ``{status, result, metadata, error}`` envelope. Posting that envelope
+    directly to ``/service/align`` must queue the task instead of failing with
+    ``INVALID_TRANSCRIPT_JSON``.
+    """
+    with open("tests/test_files/transcript.json") as f:
+        bare = json.load(f)
+
+    wrapped = {
+        "status": "completed",
+        "result": bare,
+        "metadata": {
+            "task_type": "transcription",
+            "task_params": {},
+            "language": bare["language"],
+            "file_name": "audio.wav",
+            "url": None,
+            "callback_url": None,
+            "duration": 1.0,
+            "audio_duration": 1.0,
+            "start_time": None,
+            "end_time": None,
+        },
+        "error": None,
+    }
+
+    with (
+        tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf,
+        open(AUDIO_FILE, "rb") as audio_file,
+    ):
+        json.dump(wrapped, tf)
+        tf.flush()
+        tf.seek(0)
+
+        with open(tf.name, "rb") as wrapped_fp:
+            response = client.post(
+                f"/service/align?device={os.getenv('DEVICE')}",
+                files={
+                    "transcript": ("response_task.json", wrapped_fp),
+                    "file": ("audio_file.mp3", audio_file),
+                },
+            )
+
+    assert response.status_code == 200, response.text
+    assert "Task queued" in response.json()["message"]
+
+
+@pytest.mark.e2e
 @pytest.mark.slow
 def test_diarize_service(client: TestClient) -> None:
     """Test the diarization service endpoint."""

--- a/tests/e2e/test_audio_processing_endpoints.py
+++ b/tests/e2e/test_audio_processing_endpoints.py
@@ -297,15 +297,15 @@ def test_align_service_accepts_wrapped_task_result(client: TestClient) -> None:
         "error": None,
     }
 
-    with (
-        tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf,
-        open(AUDIO_FILE, "rb") as audio_file,
-    ):
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as tf:
         json.dump(wrapped, tf)
-        tf.flush()
-        tf.seek(0)
+        temp_path = tf.name
 
-        with open(tf.name, "rb") as wrapped_fp:
+    try:
+        with (
+            open(temp_path, "rb") as wrapped_fp,
+            open(AUDIO_FILE, "rb") as audio_file,
+        ):
             response = client.post(
                 f"/service/align?device={os.getenv('DEVICE')}",
                 files={
@@ -313,6 +313,8 @@ def test_align_service_accepts_wrapped_task_result(client: TestClient) -> None:
                     "file": ("audio_file.mp3", audio_file),
                 },
             )
+    finally:
+        os.unlink(temp_path)
 
     assert response.status_code == 200, response.text
     assert "Task queued" in response.json()["message"]

--- a/tests/unit/api/test_audio_services_api.py
+++ b/tests/unit/api/test_audio_services_api.py
@@ -1,0 +1,100 @@
+"""Tests for transcript JSON parsing in the audio services API.
+
+Regression coverage for issue #525: the JSON file users download from
+``GET /task/{identifier}`` is wrapped in a ``Result`` envelope, and must be
+accepted by ``POST /service/align`` without requiring users to manually unwrap
+it.
+"""
+
+import json
+
+import pytest
+
+from app.api.audio_services_api import _parse_transcript_payload
+from app.core.exceptions import ValidationError
+
+
+BARE_TRANSCRIPT = {
+    "language": "en",
+    "segments": [
+        {"start": 0.0, "end": 1.5, "text": "Hello world."},
+    ],
+}
+
+
+def _wrap_as_task_result(transcript: dict) -> dict:
+    """Wrap a bare transcript in the envelope returned by ``GET /task/{id}``."""
+    return {
+        "status": "completed",
+        "result": transcript,
+        "metadata": {
+            "task_type": "transcription",
+            "task_params": {},
+            "language": transcript.get("language"),
+            "file_name": "audio.wav",
+            "url": None,
+            "callback_url": None,
+            "duration": 1.23,
+            "audio_duration": 1.5,
+            "start_time": "2026-05-19T13:00:00+00:00",
+            "end_time": "2026-05-19T13:00:01+00:00",
+        },
+        "error": None,
+    }
+
+
+@pytest.mark.unit
+def test_parse_bare_transcript() -> None:
+    """A bare ``{segments, language}`` transcript is parsed unchanged."""
+    payload = json.dumps(BARE_TRANSCRIPT).encode("utf-8")
+
+    transcript = _parse_transcript_payload(payload)
+
+    assert transcript.language == "en"
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0].text == "Hello world."
+
+
+@pytest.mark.unit
+def test_parse_wrapped_task_result_transcript() -> None:
+    """A ``GET /task/{id}`` envelope is auto-unwrapped (issue #525)."""
+    wrapped = _wrap_as_task_result(BARE_TRANSCRIPT)
+    payload = json.dumps(wrapped).encode("utf-8")
+
+    transcript = _parse_transcript_payload(payload)
+
+    assert transcript.language == "en"
+    assert len(transcript.segments) == 1
+    assert transcript.segments[0].text == "Hello world."
+
+
+@pytest.mark.unit
+def test_parse_invalid_json_raises_validation_error() -> None:
+    """Malformed JSON yields a ``INVALID_TRANSCRIPT_JSON`` ValidationError."""
+    with pytest.raises(ValidationError) as exc_info:
+        _parse_transcript_payload(b"not-json{{{")
+
+    assert exc_info.value.code == "INVALID_TRANSCRIPT_JSON"
+
+
+@pytest.mark.unit
+def test_parse_wrapped_with_invalid_inner_result_raises() -> None:
+    """A wrapped envelope whose ``result`` is not a valid transcript still raises."""
+    wrapped = _wrap_as_task_result({"language": "en"})  # missing segments
+    payload = json.dumps(wrapped).encode("utf-8")
+
+    with pytest.raises(ValidationError) as exc_info:
+        _parse_transcript_payload(payload)
+
+    assert exc_info.value.code == "INVALID_TRANSCRIPT_JSON"
+
+
+@pytest.mark.unit
+def test_parse_unrecognized_shape_raises() -> None:
+    """JSON that matches neither shape raises a clear ValidationError."""
+    payload = json.dumps({"foo": "bar"}).encode("utf-8")
+
+    with pytest.raises(ValidationError) as exc_info:
+        _parse_transcript_payload(payload)
+
+    assert exc_info.value.code == "INVALID_TRANSCRIPT_JSON"


### PR DESCRIPTION
## Summary

- `POST /service/align` now accepts the `Result` envelope returned by `GET /task/{identifier}` (auto-unwraps the inner `result` before validating as `Transcript`). The bare `{segments, language}` shape continues to work unchanged.
- Extracted the parsing logic into `_parse_transcript_payload` so it is independently unit-testable.
- Added 5 unit tests (bare, wrapped, invalid JSON, wrapped with invalid inner result, unrecognized shape) and an e2e regression that posts a wrapped envelope to `/service/align` and asserts the task is queued.

Closes #525

## Why

Users following the documented workflow — transcribe → download the JSON from `GET /task/{id}` → re-upload to `/service/align` — were getting a 422 `INVALID_TRANSCRIPT_JSON`, because the downloaded file is `{status, result, metadata, error}` while the endpoint validated against the bare `Transcript` shape. The fix detects the envelope (no top-level `segments`, dict-shaped `result`) and unwraps it before validation.

## Test plan

- [x] `task check` (ruff + format + mypy) — clean
- [x] `task test` — full suite passes (323/324; the one exclusion is a pre-existing `@pytest.mark.load` test that requires a live server)
- [x] Unit tests for the new parser (5)
- [x] E2e regression test posts wrapped envelope to `/service/align` and asserts 200 + "Task queued"
- [x] Coverage ≥80% (88.58% total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transcript upload validation for the /service/align endpoint with clearer error responses for invalid JSON.
  * Restored support for transcripts wrapped in task-result envelope format so uploads from that flow are accepted.

* **Tests**
  * Added end-to-end and unit tests to ensure wrapped transcripts are accepted and invalid payloads produce consistent validation errors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pavelzbornik/whisperX-FastAPI/pull/527?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->