### PR TITLE
feat(api): accept list of temperatures for fallback decoding (#520)

### DIFF
--- a/app/docs/openapi.json
+++ b/app/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "whisperX REST service",
-    "description": "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.awb', '.wma', '.amr', '.m4a', '.mp3', '.ogg', '.oga', '.aac', '.wav'}\n\n    VIDEO_EXTENSIONS = {'.avi', '.mkv', '.mov', '.mp4', '.wmv'}\n\n    ",
+    "description": "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.amr', '.oga', '.wav', '.mp3', '.wma', '.m4a', '.awb', '.ogg', '.aac'}\n\n    VIDEO_EXTENSIONS = {'.mov', '.wmv', '.avi', '.mkv', '.mp4'}\n\n    ",
     "version": "0.0.1"
   },
   "paths": {
@@ -351,12 +351,17 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "number",
-              "description": "Temperature to use for sampling",
-              "default": 0.0,
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.",
+              "default": [
+                0.0
+              ],
               "title": "Temperatures"
             },
-            "description": "Temperature to use for sampling"
+            "description": "Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription."
           },
           {
             "name": "compression_ratio_threshold",
@@ -889,12 +894,17 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "number",
-              "description": "Temperature to use for sampling",
-              "default": 0.0,
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.",
+              "default": [
+                0.0
+              ],
               "title": "Temperatures"
             },
-            "description": "Temperature to use for sampling"
+            "description": "Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription."
           },
           {
             "name": "compression_ratio_threshold",
@@ -1504,12 +1514,17 @@
             "in": "query",
             "required": false,
             "schema": {
-              "type": "number",
-              "description": "Temperature to use for sampling",
-              "default": 0.0,
+              "type": "array",
+              "items": {
+                "type": "number"
+              },
+              "description": "Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.",
+              "default": [
+                0.0
+              ],
               "title": "Temperatures"
             },
-            "description": "Temperature to use for sampling"
+            "description": "Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription."
           },
           {
             "name": "compression_ratio_threshold",

--- a/app/docs/openapi.yaml
+++ b/app/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: whisperX REST service
-  description: "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.awb', '.wma', '.amr', '.m4a', '.mp3', '.ogg', '.oga', '.aac', '.wav'}\n\n    VIDEO_EXTENSIONS = {'.avi', '.mkv', '.mov', '.mp4', '.wmv'}\n\n    "
+  description: "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.amr', '.oga', '.wav', '.mp3', '.wma', '.m4a', '.awb', '.ogg', '.aac'}\n\n    VIDEO_EXTENSIONS = {'.mov', '.wmv', '.avi', '.mkv', '.mp4'}\n\n    "
   version: 0.0.1
 paths:
   /speech-to-text:
@@ -277,11 +277,14 @@ paths:
           in: query
           required: false
           schema:
-            type: number
-            description: Temperature to use for sampling
-            default: 0.0
+            type: array
+            items:
+              type: number
+            description: Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.
+            default:
+              - 0.0
             title: Temperatures
-          description: Temperature to use for sampling
+          description: Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.
         - name: compression_ratio_threshold
           in: query
           required: false
@@ -673,11 +676,14 @@ paths:
           in: query
           required: false
           schema:
-            type: number
-            description: Temperature to use for sampling
-            default: 0.0
+            type: array
+            items:
+              type: number
+            description: Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.
+            default:
+              - 0.0
             title: Temperatures
-          description: Temperature to use for sampling
+          description: Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.
         - name: compression_ratio_threshold
           in: query
           required: false
@@ -1118,11 +1124,14 @@ paths:
           in: query
           required: false
           schema:
-            type: number
-            description: Temperature to use for sampling
-            default: 0.0
+            type: array
+            items:
+              type: number
+            description: Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.
+            default:
+              - 0.0
             title: Temperatures
-          description: Temperature to use for sampling
+          description: Temperature(s) to use for sampling. Accepts a single float or a comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable temperature fallback for long-form transcription.
         - name: compression_ratio_threshold
           in: query
           required: false

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -300,7 +300,7 @@ class ASROptions(BaseModel):
 
     @field_validator("temperatures", mode="before")
     @classmethod
-    def parse_temperatures(cls, value: float | str | list[float]) -> list[float]:
+    def parse_temperatures(cls, value: int | float | str | list[float]) -> list[float]:
         """Normalize temperatures into a list of floats.
 
         Accepts a scalar float, a comma-separated string from query params, or

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -237,8 +237,15 @@ class ASROptions(BaseModel):
     length_penalty: float = Field(
         Query(1.0, description="Optional token length penalty coefficient")
     )
-    temperatures: float = Field(
-        Query(0.0, description="Temperature to use for sampling")
+    temperatures: list[float] = Field(
+        Query(
+            [0.0],
+            description=(
+                "Temperature(s) to use for sampling. Accepts a single float or a "
+                "comma-separated list (e.g. `0.0,0.2,0.4,0.6,0.8,1.0`) to enable "
+                "temperature fallback for long-form transcription."
+            ),
+        )
     )
     compression_ratio_threshold: float = Field(
         Query(
@@ -289,6 +296,21 @@ class ASROptions(BaseModel):
         """Parse suppress tokens from a comma-separated string of token IDs into a list of integers."""
         if isinstance(value, str):
             return [int(x) for x in value.split(",")]
+        return value
+
+    @field_validator("temperatures", mode="before")
+    @classmethod
+    def parse_temperatures(cls, value: float | str | list[float]) -> list[float]:
+        """Normalize temperatures into a list of floats.
+
+        Accepts a scalar float, a comma-separated string from query params, or
+        an already-parsed list. Whisper supports a list for temperature fallback
+        on long-form transcription.
+        """
+        if isinstance(value, str):
+            return [float(x.strip()) for x in value.split(",")]
+        if isinstance(value, (int, float)):
+            return [float(value)]
         return value
 
 

--- a/tests/integration/test_whisperx_services.py
+++ b/tests/integration/test_whisperx_services.py
@@ -209,7 +209,7 @@ def test_process_audio_common_gpu(
             best_of=5,
             patience=1,
             length_penalty=1,
-            temperatures=0.0,
+            temperatures=[0.0],
             compression_ratio_threshold=2.4,
             log_prob_threshold=-1.0,
             no_speech_threshold=0.6,

--- a/tests/unit/test_schemas.py
+++ b/tests/unit/test_schemas.py
@@ -1,0 +1,40 @@
+"""Tests for pydantic schema validators in app/schemas.py."""
+
+import pytest
+
+from app.schemas import ASROptions
+
+
+class TestASROptionsTemperatures:
+    """Tests for ASROptions.temperatures supporting a single float or a list."""
+
+    def test_single_float_is_wrapped_in_list(self) -> None:
+        """A scalar float input is normalized to a single-element list."""
+        options = ASROptions(temperatures=0.4)
+        assert options.temperatures == [0.4]
+
+    def test_list_of_floats_passes_through(self) -> None:
+        """A list of floats is preserved as-is."""
+        values = [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+        options = ASROptions(temperatures=values)
+        assert options.temperatures == values
+
+    def test_comma_separated_string_is_parsed(self) -> None:
+        """A comma-separated string (from a query param) is parsed into floats."""
+        options = ASROptions(temperatures="0.0,0.2,0.4,0.6,0.8,1.0")
+        assert options.temperatures == [0.0, 0.2, 0.4, 0.6, 0.8, 1.0]
+
+    def test_comma_separated_string_tolerates_whitespace(self) -> None:
+        """Whitespace around comma-separated values is stripped before parsing."""
+        options = ASROptions(temperatures="0.0, 0.2 , 0.4")
+        assert options.temperatures == [0.0, 0.2, 0.4]
+
+    def test_single_value_string_is_parsed_as_one_element_list(self) -> None:
+        """A string with a single numeric value parses to a one-element list."""
+        options = ASROptions(temperatures="0.5")
+        assert options.temperatures == [0.5]
+
+    def test_invalid_string_raises(self) -> None:
+        """A non-numeric token in the string raises a validation error."""
+        with pytest.raises(ValueError):
+            ASROptions(temperatures="0.0,abc,0.4")


### PR DESCRIPTION
## Summary

Closes #520. Allows `ASROptions.temperatures` to accept either a single float or a list of floats (e.g. `0.0,0.2,0.4,0.6,0.8,1.0` as a comma-separated query param). This enables Whisper's long-form temperature fallback as described in the [Whisper paper](https://cdn.openai.com/papers/whisper.pdf) and the HF docs linked in the issue.

- `app/schemas.py` — change `temperatures` type to `list[float]` and add a `parse_temperatures` validator (mirrors the existing `parse_suppress_tokens` pattern).
- The value flows unchanged into `whisperx.load_model(asr_options=...)` → `faster_whisper.TranscriptionOptions.temperatures: List[float]`, which already supports a list natively (whisperx's own default is `[0.0, 0.2, 0.4, 0.6, 0.8, 1.0]`).
- OpenAPI docs regenerated by pre-commit hook.

## Test plan

- [x] New unit tests in `tests/unit/test_schemas.py` cover scalar input, list input, comma-separated string, whitespace tolerance, single-value string, and invalid input.
- [x] Existing integration test in `tests/integration/test_whisperx_services.py` updated to pass `temperatures=[0.0]`.
- [x] `task check` (ruff + mypy) — clean.
- [x] `task test` — 330 passed, coverage 88.62% (≥ 80% gate); `app/schemas.py` at 99%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `temperatures` parameter now accepts multiple values for temperature fallback across transcription endpoints. Supports comma-separated lists or arrays with default value `[0.0]`.

* **Documentation**
  * Updated API specifications with refined supported file extensions and temperature parameter details.

* **Tests**
  * Added test coverage for temperature parameter validation and parsing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pavelzbornik/whisperX-FastAPI/pull/529?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->