### PR TITLE
feat(security): API-wide rate limiting, upload cap, concurrency caps, and auth

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,6 +64,32 @@ LOG_FORMAT=text
 FILTER_WARNING=true
 
 # ============================================
+# API Protection (all no-op by default)
+# ============================================
+# Reject uploads larger than this many MB with HTTP 413 (0 = unlimited)
+MAX_UPLOAD_SIZE_MB=0
+
+# Cap on concurrent in-flight GPU requests across the API (0 = unlimited);
+# requests beyond the cap get HTTP 503 with a Retry-After header.
+MAX_QUEUED_GPU_REQUESTS=0
+
+# Fraction of MAX_QUEUED_GPU_REQUESTS reserved for the synchronous
+# (OpenAI-compatible /v1/audio/*) path; the async path gets the remainder.
+SYNC_GPU_QUOTA_FRACTION=0.5
+
+# Per-caller rate limiting (slowapi) -> HTTP 429 with Retry-After
+RATE_LIMIT__ENABLED=false
+RATE_LIMIT__REQUESTS_PER_MINUTE=60
+RATE_LIMIT__BURST=10
+# How callers are identified: ip | bearer_token
+RATE_LIMIT__KEY_STRATEGY=ip
+
+# Shared bearer-token authentication -> HTTP 401 when missing/invalid
+AUTH__ENABLED=false
+# Required when AUTH__ENABLED=true
+AUTH__BEARER_TOKEN=
+
+# ============================================
 # Notes
 # ============================================
 # - Required fields: HF_TOKEN (for model downloads)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,10 +107,26 @@ LOG_LEVEL=INFO
 ENVIRONMENT=production
 DB_URL=sqlite:///records.db
 MAX_CONCURRENT_GPU_TASKS=1          # max simultaneous GPU tasks (prevents OOM)
+
+# API protection (all no-op by default — see app/core/config.py)
+MAX_UPLOAD_SIZE_MB=0               # 413 over this many MB; 0 = unlimited
+MAX_QUEUED_GPU_REQUESTS=0         # 503 when in-flight GPU requests exceed cap; 0 = unlimited
+SYNC_GPU_QUOTA_FRACTION=0.5       # share of MAX_QUEUED_GPU_REQUESTS for the sync (/v1/audio/*) path
+RATE_LIMIT__ENABLED=false         # slowapi per-caller limiting → 429 + Retry-After
+RATE_LIMIT__REQUESTS_PER_MINUTE=60
+RATE_LIMIT__BURST=10
+RATE_LIMIT__KEY_STRATEGY=ip       # ip | bearer_token
+AUTH__ENABLED=false               # shared bearer-token auth → 401
+AUTH__BEARER_TOKEN=               # required when AUTH__ENABLED=true
 ```
 
 **Critical:** When `DEVICE=cpu`, `COMPUTE_TYPE` is auto-corrected to `int8`. Tests set
 `DEVICE=cpu` and `COMPUTE_TYPE=int8` automatically.
+
+**API protection** (rate limiting, upload cap, route concurrency caps, bearer auth) lives
+in `app/core/{rate_limit,concurrency}.py`, `app/api/{middleware,security}.py`, and is wired
+in `main.py`. All knobs read `get_settings()` per request so they toggle at runtime and stay
+no-op until enabled. Multi-worker deployments give each worker its own in-process budget.
 
 ## CI Pipeline
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,12 @@ AUTH__BEARER_TOKEN=               # required when AUTH__ENABLED=true
 
 **API protection** (rate limiting, upload cap, route concurrency caps, bearer auth) lives
 in `app/core/{rate_limit,concurrency}.py`, `app/api/{middleware,security}.py`, and is wired
-in `main.py`. All knobs read `get_settings()` per request so they toggle at runtime and stay
-no-op until enabled. Multi-worker deployments give each worker its own in-process budget.
+in `main.py`. Knobs come from `get_settings()` (loaded from env/`.env` at startup and
+`lru_cache`-backed), so they are fixed for the life of the process and stay no-op until
+enabled — changing them needs a restart (tests clear the caches to re-read). The upload cap
+is enforced from `Content-Length`; the async concurrency gate is admission control (the
+background GPU pipeline is bounded by `MAX_CONCURRENT_GPU_TASKS`). Multi-worker deployments
+give each worker its own in-process budget.
 
 ## CI Pipeline
 

--- a/README.md
+++ b/README.md
@@ -213,6 +213,42 @@ WhisperX supports these model sizes:
 
 Set default model in `.env` using `WHISPER_MODEL=` (default: tiny)
 
+### API protection: upload cap, rate limiting, concurrency, and auth
+
+The transcription endpoints (`/speech-to-text`, `/service/*`, `/v1/audio/*`) can be
+protected with optional, configurable safeguards. **Every option is a no-op by default**,
+so existing deployments are unaffected until they opt in.
+
+| Variable | Default | Effect |
+| --- | --- | --- |
+| `MAX_UPLOAD_SIZE_MB` | `0` | Reject uploads larger than this many MB with HTTP 413 (checked from `Content-Length` before the body is read). `0` = unlimited. |
+| `MAX_QUEUED_GPU_REQUESTS` | `0` | Cap on concurrent in-flight GPU requests across the API, returning HTTP 503 (with `Retry-After`) when exceeded. `0` = unlimited. |
+| `SYNC_GPU_QUOTA_FRACTION` | `0.5` | Fraction of `MAX_QUEUED_GPU_REQUESTS` reserved for the synchronous (`/v1/audio/*`) path; the async background path gets the remainder. Each path is guaranteed at least one slot when a cap is set. |
+| `RATE_LIMIT__ENABLED` | `false` | Enable per-caller rate limiting (slowapi). Returns HTTP 429 with `Retry-After`. |
+| `RATE_LIMIT__REQUESTS_PER_MINUTE` | `60` | Sustained per-caller budget per minute. |
+| `RATE_LIMIT__BURST` | `10` | Short-term per-caller burst budget per second. |
+| `RATE_LIMIT__KEY_STRATEGY` | `ip` | How callers are identified: `ip` or `bearer_token`. |
+| `AUTH__ENABLED` | `false` | Require a shared bearer token on protected endpoints (HTTP 401 otherwise). |
+| `AUTH__BEARER_TOKEN` | _(empty)_ | The shared token. **Required when `AUTH__ENABLED=true`.** |
+
+Example `.env` snippet enabling all of them:
+
+```sh
+MAX_UPLOAD_SIZE_MB=25
+MAX_QUEUED_GPU_REQUESTS=20
+SYNC_GPU_QUOTA_FRACTION=0.5
+RATE_LIMIT__ENABLED=true
+RATE_LIMIT__REQUESTS_PER_MINUTE=60
+RATE_LIMIT__BURST=10
+RATE_LIMIT__KEY_STRATEGY=ip
+AUTH__ENABLED=true
+AUTH__BEARER_TOKEN=replace-with-a-long-random-secret
+```
+
+> **Note:** Rate-limit and concurrency state are kept in-process. Running multiple workers
+> (`uvicorn --workers >1`) gives each worker its own budget, so these limits — like the GPU
+> semaphore — assume a single worker process.
+
 ## System Requirements
 
 - NVIDIA GPU with CUDA 12.8+ support

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ so existing deployments are unaffected until they opt in.
 
 | Variable | Default | Effect |
 | --- | --- | --- |
-| `MAX_UPLOAD_SIZE_MB` | `0` | Reject uploads larger than this many MB with HTTP 413 (checked from `Content-Length` before the body is read). `0` = unlimited. |
-| `MAX_QUEUED_GPU_REQUESTS` | `0` | Cap on concurrent in-flight GPU requests across the API, returning HTTP 503 (with `Retry-After`) when exceeded. `0` = unlimited. |
-| `SYNC_GPU_QUOTA_FRACTION` | `0.5` | Fraction of `MAX_QUEUED_GPU_REQUESTS` reserved for the synchronous (`/v1/audio/*`) path; the async background path gets the remainder. Each path is guaranteed at least one slot when a cap is set. |
+| `MAX_UPLOAD_SIZE_MB` | `0` | Reject uploads larger than this many MB with HTTP 413, checked from `Content-Length` before the body is read. `0` = unlimited. (Requests without a `Content-Length`, e.g. chunked uploads, are not pre-checked — see the note below.) |
+| `MAX_QUEUED_GPU_REQUESTS` | `0` | Cap on concurrent in-flight transcription **requests** admitted across the API, returning HTTP 503 (with `Retry-After`) when exceeded. `0` = unlimited. Use `>= 2` for an exact split; `1` admits up to 2 (one per path). |
+| `SYNC_GPU_QUOTA_FRACTION` | `0.5` | Fraction of `MAX_QUEUED_GPU_REQUESTS` reserved for the synchronous (`/v1/audio/*`) path; the async path gets the remainder. For `total >= 2` the split is exact and each path keeps at least one slot. |
 | `RATE_LIMIT__ENABLED` | `false` | Enable per-caller rate limiting (slowapi). Returns HTTP 429 with `Retry-After`. |
 | `RATE_LIMIT__REQUESTS_PER_MINUTE` | `60` | Sustained per-caller budget per minute. |
 | `RATE_LIMIT__BURST` | `10` | Short-term per-caller burst budget per second. |
@@ -245,9 +245,19 @@ AUTH__ENABLED=true
 AUTH__BEARER_TOKEN=replace-with-a-long-random-secret
 ```
 
-> **Note:** Rate-limit and concurrency state are kept in-process. Running multiple workers
-> (`uvicorn --workers >1`) gives each worker its own budget, so these limits — like the GPU
-> semaphore — assume a single worker process.
+> **Notes:**
+>
+> - Values are read from the environment at startup and are fixed for the life of the
+>   process; changing them requires a restart.
+> - Rate-limit and concurrency state are kept in-process. Running multiple workers
+>   (`uvicorn --workers >1`) gives each worker its own budget, so these limits — like the
+>   GPU semaphore — assume a single worker process.
+> - The upload cap is enforced from the `Content-Length` header. Uploads sent without one
+>   (chunked transfer encoding) are not rejected up front and are bounded only by available
+>   memory/disk; the common multipart upload path always sends `Content-Length`.
+> - For async endpoints (`/speech-to-text`, `/service/*`), the concurrency gate is
+>   **admission control** for the request phase (validation, audio decode, enqueue). The GPU
+>   pipeline runs in a background task bounded by `MAX_CONCURRENT_GPU_TASKS`, not by this gate.
 
 ## System Requirements
 

--- a/app/api/audio_api.py
+++ b/app/api/audio_api.py
@@ -13,13 +13,16 @@ from fastapi import (
     Depends,
     File,
     Form,
+    Request,
     UploadFile,
 )
+from starlette.responses import Response as StarletteResponse
 
 from app.api.dependencies import get_file_service, get_task_repository
 from app.audio import get_audio_duration, process_audio_file
 from app.core.exceptions import FileValidationError
 from app.core.logging import logger
+from app.core.rate_limit import limiter, rate_limit_value, rate_limiting_disabled
 from app.domain.entities.task import Task as DomainTask
 from app.domain.repositories.task_repository import ITaskRepository
 from app.files import ALLOWED_EXTENSIONS
@@ -48,7 +51,10 @@ stt_router = APIRouter()
 
 
 @stt_router.post("/speech-to-text", tags=["Speech-2-Text"])
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def speech_to_text(
+    request: Request,
+    response: StarletteResponse,
     background_tasks: BackgroundTasks,
     model_params: WhisperModelParams = Depends(),
     align_params: AlignmentParams = Depends(),
@@ -136,7 +142,10 @@ async def speech_to_text(
 @stt_router.post(
     "/speech-to-text-url", callbacks=task_callback_router.routes, tags=["Speech-2-Text"]
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def speech_to_text_url(
+    request: Request,
+    response: StarletteResponse,
     background_tasks: BackgroundTasks,
     model_params: WhisperModelParams = Depends(),
     align_params: AlignmentParams = Depends(),

--- a/app/api/audio_services_api.py
+++ b/app/api/audio_services_api.py
@@ -14,9 +14,11 @@ from fastapi import (
     Depends,
     File,
     Query,
+    Request,
     UploadFile,
 )
 from pydantic import ValidationError as PydanticValidationError
+from starlette.responses import Response as StarletteResponse
 
 from app.api.constants import (
     JSON_EXTENSION,
@@ -35,6 +37,7 @@ from app.audio import get_audio_duration, process_audio_file
 from app.core.config import Config
 from app.core.exceptions import FileValidationError, ValidationError
 from app.core.logging import logger
+from app.core.rate_limit import limiter, rate_limit_value, rate_limiting_disabled
 from app.domain.entities.task import Task as DomainTask
 from app.domain.repositories.task_repository import ITaskRepository
 from app.domain.services.alignment_service import IAlignmentService
@@ -110,7 +113,10 @@ def _parse_transcript_payload(payload: bytes) -> Transcript:
     tags=["Speech-2-Text services"],
     name="1. Transcribe",
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def transcribe(
+    request: Request,
+    response: StarletteResponse,
     background_tasks: BackgroundTasks,
     model_params: WhisperModelParams = Depends(),
     asr_options_params: ASROptions = Depends(),
@@ -183,7 +189,10 @@ async def transcribe(
     tags=["Speech-2-Text services"],
     name="2. Align Transcript",
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def align(
+    request: Request,
+    response: StarletteResponse,
     background_tasks: BackgroundTasks,
     transcript: UploadFile = File(
         ..., description="Whisper style transcript json file"
@@ -276,7 +285,10 @@ async def align(
 @service_router.post(
     "/service/diarize", tags=["Speech-2-Text services"], name="3. Diarize"
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def diarize(
+    request: Request,
+    response: StarletteResponse,
     background_tasks: BackgroundTasks,
     file: UploadFile = File(...),
     repository: ITaskRepository = Depends(get_task_repository),
@@ -347,7 +359,10 @@ async def diarize(
     tags=["Speech-2-Text services"],
     name="4. Combine Transcript and Diarization result",
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def combine(
+    request: Request,
+    response: StarletteResponse,
     background_tasks: BackgroundTasks,
     aligned_transcript: UploadFile = File(...),
     diarization_result: UploadFile = File(...),

--- a/app/api/exception_handlers.py
+++ b/app/api/exception_handlers.py
@@ -8,11 +8,14 @@ import logging
 import uuid
 
 from fastapi import Request, status
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, Response
+from slowapi.errors import RateLimitExceeded
 
 from app.core.exceptions import (
+    AuthenticationError,
     DomainError,
     InfrastructureError,
+    ServiceOverloadedError,
     SpeakerNotFoundError,
     TaskNotFoundError,
     ValidationError,
@@ -223,3 +226,110 @@ def generic_error_handler(request: Request, exc: Exception) -> JSONResponse:
             }
         },
     )
+
+
+def authentication_error_handler(
+    request: Request, exc: AuthenticationError | Exception
+) -> JSONResponse:
+    """Handle authentication failures.
+
+    Maps to HTTP 401 Unauthorized with a ``WWW-Authenticate: Bearer`` header so
+    clients know how to authenticate.
+
+    Args:
+        request: FastAPI request object
+        exc: Authentication error exception
+
+    Returns:
+        JSONResponse with error details and HTTP 401 status
+    """
+    auth_exc = exc if isinstance(exc, AuthenticationError) else AuthenticationError()
+
+    logger.info(
+        "Authentication failed: %s",
+        auth_exc.message,
+        extra={"correlation_id": auth_exc.correlation_id, "path": request.url.path},
+    )
+
+    return JSONResponse(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        content=auth_exc.to_dict(),
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def service_overloaded_handler(
+    request: Request, exc: ServiceOverloadedError | Exception
+) -> JSONResponse:
+    """Handle route-level concurrency-cap rejections.
+
+    Maps to HTTP 503 Service Unavailable with a ``Retry-After`` header.
+
+    Args:
+        request: FastAPI request object
+        exc: Service overloaded error exception
+
+    Returns:
+        JSONResponse with error details and HTTP 503 status
+    """
+    over_exc = (
+        exc
+        if isinstance(exc, ServiceOverloadedError)
+        else ServiceOverloadedError(scope="unknown")
+    )
+
+    logger.warning(
+        "Service overloaded: %s",
+        over_exc.message,
+        extra={"correlation_id": over_exc.correlation_id, "path": request.url.path},
+    )
+
+    return JSONResponse(
+        status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+        content=over_exc.to_dict(),
+        headers={"Retry-After": str(over_exc.retry_after)},
+    )
+
+
+def rate_limit_exceeded_handler(
+    request: Request, exc: RateLimitExceeded | Exception
+) -> Response:
+    """Handle slowapi rate-limit rejections.
+
+    Maps to HTTP 429 Too Many Requests with an OpenAI-style error envelope and
+    a ``Retry-After`` header (injected via the limiter when available).
+
+    Args:
+        request: FastAPI request object
+        exc: Rate limit exceeded exception
+
+    Returns:
+        JSONResponse with error details and HTTP 429 status
+    """
+    correlation_id = str(uuid.uuid4())
+    detail = getattr(exc, "detail", "")
+
+    logger.info(
+        "Rate limit exceeded: %s",
+        detail,
+        extra={"correlation_id": correlation_id, "path": request.url.path},
+    )
+
+    response: Response = JSONResponse(
+        status_code=status.HTTP_429_TOO_MANY_REQUESTS,
+        content={
+            "error": {
+                "message": f"Rate limit exceeded: {detail}",
+                "type": "rate_limit_error",
+                "code": "RATE_LIMIT_EXCEEDED",
+                "correlation_id": correlation_id,
+            }
+        },
+    )
+
+    limiter = getattr(request.app.state, "limiter", None)
+    view_rate_limit = getattr(request.state, "view_rate_limit", None)
+    if limiter is not None and view_rate_limit is not None:
+        response = limiter._inject_headers(response, view_rate_limit)
+
+    return response

--- a/app/api/middleware.py
+++ b/app/api/middleware.py
@@ -1,0 +1,72 @@
+"""ASGI middleware for request shaping (upload size cap)."""
+
+from starlette.responses import JSONResponse
+from starlette.types import ASGIApp, Receive, Scope, Send
+
+from app.core.config import get_settings
+
+# Methods that can carry a request body worth size-checking.
+_BODY_METHODS = frozenset({"POST", "PUT", "PATCH"})
+
+
+class MaxUploadSizeMiddleware:
+    """Reject oversized uploads with HTTP 413 before the body is read.
+
+    Enforced from the ``Content-Length`` header so the request body is never
+    buffered to disk when it exceeds ``MAX_UPLOAD_SIZE_MB``. A cap of ``0``
+    (the default) disables the check entirely, preserving prior behavior.
+    Implemented as raw ASGI middleware so the response is produced without
+    invoking the downstream application.
+    """
+
+    def __init__(self, app: ASGIApp) -> None:
+        """Initialise with the wrapped ASGI application.
+
+        Args:
+            app: The next ASGI application in the stack.
+        """
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Reject oversized HTTP requests, otherwise defer to the inner app.
+
+        Args:
+            scope: ASGI connection scope.
+            receive: ASGI receive callable.
+            send: ASGI send callable.
+        """
+        if scope["type"] != "http" or scope.get("method") not in _BODY_METHODS:
+            await self.app(scope, receive, send)
+            return
+
+        max_mb = get_settings().MAX_UPLOAD_SIZE_MB
+        if max_mb <= 0:
+            await self.app(scope, receive, send)
+            return
+
+        max_bytes = max_mb * 1024 * 1024
+        headers = dict(scope.get("headers", []))
+        raw_length = headers.get(b"content-length")
+        if raw_length is not None:
+            try:
+                content_length = int(raw_length)
+            except ValueError:
+                content_length = -1
+            if content_length > max_bytes:
+                response = JSONResponse(
+                    status_code=413,
+                    content={
+                        "error": {
+                            "message": (
+                                "Upload exceeds the maximum allowed size of "
+                                f"{max_mb} MB."
+                            ),
+                            "type": "invalid_request_error",
+                            "code": "REQUEST_TOO_LARGE",
+                        }
+                    },
+                )
+                await response(scope, receive, send)
+                return
+
+        await self.app(scope, receive, send)

--- a/app/api/openai_compat_api.py
+++ b/app/api/openai_compat_api.py
@@ -34,6 +34,7 @@ from app.core.exceptions import (
 )
 from app.core.gpu_semaphore import get_gpu_semaphore
 from app.core.logging import logger
+from app.core.rate_limit import limiter, rate_limit_value, rate_limiting_disabled
 from app.domain.entities.task import Task as DomainTask
 from app.domain.repositories.task_repository import ITaskRepository
 from app.domain.services.alignment_service import IAlignmentService
@@ -440,6 +441,7 @@ async def _handle_openai_transcription(
     summary="Transcribe audio synchronously with an OpenAI-compatible API",
     responses=_OPENAI_NON_JSON_RESPONSES,
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def create_transcription(
     request: Request,
     file_service: Annotated[FileService, Depends(get_file_service)],
@@ -472,6 +474,7 @@ async def create_transcription(
     summary="Translate audio to English synchronously with an OpenAI-compatible API",
     responses=_OPENAI_NON_JSON_RESPONSES,
 )
+@limiter.limit(rate_limit_value, exempt_when=rate_limiting_disabled)
 async def create_translation(
     request: Request,
     file_service: Annotated[FileService, Depends(get_file_service)],

--- a/app/api/security.py
+++ b/app/api/security.py
@@ -1,0 +1,91 @@
+"""FastAPI security dependencies: bearer-token auth and concurrency gates.
+
+All dependencies read :func:`app.core.config.get_settings` per request, so the
+relevant features stay off (no-op) until explicitly enabled and can be toggled
+at runtime without rebuilding the application.
+"""
+
+import hmac
+from collections.abc import AsyncGenerator
+from typing import Annotated
+
+from fastapi import Header
+
+from app.core.concurrency import (
+    get_async_concurrency_gate,
+    get_sync_concurrency_gate,
+)
+from app.core.config import get_settings
+from app.core.exceptions import AuthenticationError, ServiceOverloadedError
+
+
+def verify_bearer_token(
+    authorization: Annotated[str | None, Header()] = None,
+) -> None:
+    """Validate the shared bearer token when authentication is enabled.
+
+    A no-op when ``AUTH__ENABLED`` is false (the default), preserving the prior
+    unauthenticated behavior. When enabled, a missing or non-matching token is
+    rejected with :class:`AuthenticationError` (HTTP 401). The comparison is
+    constant-time to avoid leaking the token via timing.
+
+    Args:
+        authorization: The raw ``Authorization`` request header, if present.
+
+    Raises:
+        AuthenticationError: If auth is enabled and the token is absent/invalid.
+    """
+    settings = get_settings()
+    if not settings.auth.ENABLED:
+        return
+
+    if not authorization or not authorization.lower().startswith("bearer "):
+        raise AuthenticationError(reason="Missing bearer token")
+
+    presented = authorization[len("bearer ") :].strip()
+    if not presented or not hmac.compare_digest(presented, settings.auth.BEARER_TOKEN):
+        raise AuthenticationError(reason="Invalid bearer token")
+
+
+async def enforce_sync_gpu_quota() -> AsyncGenerator[None, None]:
+    """Hold a slot on the synchronous-path concurrency gate for the request.
+
+    Rejects with :class:`ServiceOverloadedError` (HTTP 503) when the sync budget
+    is exhausted instead of stalling the connection. The slot is released when
+    the request finishes. A no-op when ``MAX_QUEUED_GPU_REQUESTS`` is 0.
+
+    Yields:
+        None — control returns to the request handler while the slot is held.
+
+    Raises:
+        ServiceOverloadedError: If no sync slot is currently available.
+    """
+    gate = get_sync_concurrency_gate()
+    if not gate.acquire():
+        raise ServiceOverloadedError(scope="sync")
+    try:
+        yield
+    finally:
+        gate.release()
+
+
+async def enforce_async_gpu_quota() -> AsyncGenerator[None, None]:
+    """Hold a slot on the asynchronous-path concurrency gate for the request.
+
+    Rejects with :class:`ServiceOverloadedError` (HTTP 503) when the async
+    budget is exhausted. The slot is released when the request finishes. A no-op
+    when ``MAX_QUEUED_GPU_REQUESTS`` is 0.
+
+    Yields:
+        None — control returns to the request handler while the slot is held.
+
+    Raises:
+        ServiceOverloadedError: If no async slot is currently available.
+    """
+    gate = get_async_concurrency_gate()
+    if not gate.acquire():
+        raise ServiceOverloadedError(scope="async")
+    try:
+        yield
+    finally:
+        gate.release()

--- a/app/api/security.py
+++ b/app/api/security.py
@@ -1,8 +1,9 @@
 """FastAPI security dependencies: bearer-token auth and concurrency gates.
 
-All dependencies read :func:`app.core.config.get_settings` per request, so the
-relevant features stay off (no-op) until explicitly enabled and can be toggled
-at runtime without rebuilding the application.
+Configuration is read from :func:`app.core.config.get_settings`, which is loaded
+once from the environment/``.env`` at startup (it is ``lru_cache``-backed). The
+relevant features stay off (no-op) until explicitly enabled; changing the values
+requires a process restart. Tests clear the relevant caches to re-read them.
 """
 
 import hmac
@@ -20,7 +21,7 @@ from app.core.exceptions import AuthenticationError, ServiceOverloadedError
 
 
 def verify_bearer_token(
-    authorization: Annotated[str | None, Header()] = None,
+    authorization: Annotated[str | None, Header(alias="Authorization")] = None,
 ) -> None:
     """Validate the shared bearer token when authentication is enabled.
 
@@ -72,9 +73,15 @@ async def enforce_sync_gpu_quota() -> AsyncGenerator[None, None]:
 async def enforce_async_gpu_quota() -> AsyncGenerator[None, None]:
     """Hold a slot on the asynchronous-path concurrency gate for the request.
 
+    Admission control for the async endpoints: the slot is held only for the
+    request phase (file validation, audio decode, task enqueue) and released
+    when the HTTP response is sent. The GPU pipeline itself runs later in a
+    background task and is bounded by the GPU semaphore
+    (``MAX_CONCURRENT_GPU_TASKS``), not by this gate — so this caps how many
+    async requests are admitted concurrently, not the queued background backlog.
+
     Rejects with :class:`ServiceOverloadedError` (HTTP 503) when the async
-    budget is exhausted. The slot is released when the request finishes. A no-op
-    when ``MAX_QUEUED_GPU_REQUESTS`` is 0.
+    budget is exhausted. A no-op when ``MAX_QUEUED_GPU_REQUESTS`` is 0.
 
     Yields:
         None — control returns to the request handler while the slot is held.

--- a/app/core/concurrency.py
+++ b/app/core/concurrency.py
@@ -1,0 +1,100 @@
+"""Route-level concurrency gates for GPU-bound request paths.
+
+These gates are separate from the GPU ``threading.Semaphore`` (which protects
+VRAM). They cap how many GPU-bound requests may be in flight per path so the
+anyio threadpool and connection slots are not exhausted, and so synchronous
+(OpenAI-compatible) traffic and asynchronous background traffic each receive a
+guaranteed share of the overall budget rather than starving one another.
+
+The total budget is ``MAX_QUEUED_GPU_REQUESTS`` split by
+``SYNC_GPU_QUOTA_FRACTION``. A total of ``0`` means unlimited (no-op), which is
+the default so existing deployments are unaffected.
+"""
+
+import threading
+from functools import lru_cache
+
+from app.core.config import get_settings
+from app.core.logging import logger
+
+
+class ConcurrencyGate:
+    """A non-blocking concurrency limiter.
+
+    A capacity of ``0`` means unlimited and the gate becomes a no-op:
+    :meth:`acquire` always succeeds and :meth:`release` does nothing.
+    """
+
+    def __init__(self, capacity: int) -> None:
+        """Initialise the gate.
+
+        Args:
+            capacity: Maximum number of simultaneous holders, or 0 for unlimited.
+        """
+        self._capacity = capacity
+        self._semaphore = threading.BoundedSemaphore(capacity) if capacity > 0 else None
+
+    @property
+    def capacity(self) -> int:
+        """Return the configured slot count, where 0 means unlimited."""
+        return self._capacity
+
+    def acquire(self) -> bool:
+        """Try to acquire a slot without blocking.
+
+        Returns:
+            True if a slot was acquired (or the gate is unlimited), else False.
+        """
+        if self._semaphore is None:
+            return True
+        return self._semaphore.acquire(blocking=False)
+
+    def release(self) -> None:
+        """Release a previously acquired slot (no-op when unlimited)."""
+        if self._semaphore is not None:
+            self._semaphore.release()
+
+
+def compute_quota_split(total: int, sync_fraction: float) -> tuple[int, int]:
+    """Split a total budget into ``(sync_capacity, async_capacity)``.
+
+    A ``total`` of 0 (or less) yields ``(0, 0)`` meaning both paths are
+    unlimited. When a cap is set, each path is guaranteed at least one slot so a
+    fraction of 0 or 1 cannot completely lock out either path.
+
+    Args:
+        total: The overall concurrent-request budget.
+        sync_fraction: Fraction of the budget reserved for the sync path.
+
+    Returns:
+        Tuple of (sync capacity, async capacity).
+    """
+    if total <= 0:
+        return 0, 0
+    sync_capacity = max(1, int(round(total * sync_fraction)))
+    async_capacity = max(1, total - sync_capacity)
+    return sync_capacity, async_capacity
+
+
+@lru_cache(maxsize=1)
+def get_sync_concurrency_gate() -> ConcurrencyGate:
+    """Return the shared concurrency gate for the synchronous request path."""
+    settings = get_settings()
+    sync_capacity, _ = compute_quota_split(
+        settings.MAX_QUEUED_GPU_REQUESTS, settings.SYNC_GPU_QUOTA_FRACTION
+    )
+    logger.info("Sync GPU concurrency gate initialized with capacity=%d", sync_capacity)
+    return ConcurrencyGate(sync_capacity)
+
+
+@lru_cache(maxsize=1)
+def get_async_concurrency_gate() -> ConcurrencyGate:
+    """Return the shared concurrency gate for the asynchronous request path."""
+    settings = get_settings()
+    _, async_capacity = compute_quota_split(
+        settings.MAX_QUEUED_GPU_REQUESTS, settings.SYNC_GPU_QUOTA_FRACTION
+    )
+    logger.info(
+        "Async GPU concurrency gate initialized with capacity=%d", async_capacity
+    )
+    return ConcurrencyGate(async_capacity)

--- a/app/core/concurrency.py
+++ b/app/core/concurrency.py
@@ -59,8 +59,12 @@ def compute_quota_split(total: int, sync_fraction: float) -> tuple[int, int]:
     """Split a total budget into ``(sync_capacity, async_capacity)``.
 
     A ``total`` of 0 (or less) yields ``(0, 0)`` meaning both paths are
-    unlimited. When a cap is set, each path is guaranteed at least one slot so a
-    fraction of 0 or 1 cannot completely lock out either path.
+    unlimited. For ``total >= 2`` the split is exact (``sync + async == total``)
+    while guaranteeing each path at least one slot, so a fraction of 0 or 1
+    cannot lock out either path. The sole exception is ``total == 1``: since a
+    capacity of 0 means "unlimited" rather than "no slots", both paths get 1,
+    allowing up to 2 concurrent requests. Set ``MAX_QUEUED_GPU_REQUESTS >= 2``
+    for a split where the combined cap equals the configured total.
 
     Args:
         total: The overall concurrent-request budget.
@@ -71,9 +75,12 @@ def compute_quota_split(total: int, sync_fraction: float) -> tuple[int, int]:
     """
     if total <= 0:
         return 0, 0
-    sync_capacity = max(1, int(round(total * sync_fraction)))
-    async_capacity = max(1, total - sync_capacity)
-    return sync_capacity, async_capacity
+    if total == 1:
+        return 1, 1
+    # Clamp the sync share to [1, total - 1] so the async path keeps >= 1 slot
+    # and the two shares always sum to exactly ``total``.
+    sync_capacity = min(max(round(total * sync_fraction), 1), total - 1)
+    return sync_capacity, total - sync_capacity
 
 
 @lru_cache(maxsize=1)

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,5 +1,6 @@
 """Configuration module for the WhisperX FastAPI application."""
 
+from enum import Enum
 from functools import lru_cache
 from typing import Optional
 
@@ -8,6 +9,13 @@ from pydantic import Field, computed_field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from app.schemas import ComputeType, Device, WhisperModel
+
+
+class RateLimitKeyStrategy(str, Enum):
+    """Strategy used to derive the rate-limit bucket key for a request."""
+
+    ip = "ip"
+    bearer_token = "bearer_token"
 
 
 class DatabaseSettings(BaseSettings):
@@ -156,6 +164,74 @@ class SsrfSettings(BaseSettings):
     )
 
 
+class RateLimitSettings(BaseSettings):
+    """Per-caller rate limiting configuration (slowapi-backed).
+
+    Disabled by default so existing deployments are unaffected until they
+    opt in. Each option is configured via an environment variable prefixed
+    with ``RATE_LIMIT__``, for example ``RATE_LIMIT__ENABLED`` or
+    ``RATE_LIMIT__REQUESTS_PER_MINUTE``.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="RATE_LIMIT__",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
+    ENABLED: bool = Field(
+        default=False,
+        description="Enable per-caller rate limiting on transcription endpoints",
+    )
+    REQUESTS_PER_MINUTE: int = Field(
+        default=60,
+        ge=1,
+        description="Sustained request budget per caller per minute",
+    )
+    BURST: int = Field(
+        default=10,
+        ge=1,
+        description="Short-term burst budget per caller per second",
+    )
+    KEY_STRATEGY: RateLimitKeyStrategy = Field(
+        default=RateLimitKeyStrategy.ip,
+        description="How callers are identified: client IP or bearer token",
+    )
+
+
+class AuthSettings(BaseSettings):
+    """Optional shared bearer-token authentication configuration.
+
+    Disabled by default so existing deployments are unaffected until they
+    opt in. Configured via environment variables prefixed with ``AUTH__``,
+    for example ``AUTH__ENABLED`` or ``AUTH__BEARER_TOKEN``.
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="AUTH__",
+        case_sensitive=True,
+        extra="ignore",
+    )
+
+    ENABLED: bool = Field(
+        default=False,
+        description="Require a valid bearer token on protected endpoints",
+    )
+    BEARER_TOKEN: str = Field(
+        default="",
+        description="Shared bearer token required when AUTH__ENABLED is true",
+    )
+
+    @model_validator(mode="after")
+    def validate_token_present_when_enabled(self) -> "AuthSettings":
+        """Require a non-empty token when authentication is enabled."""
+        if self.ENABLED and not self.BEARER_TOKEN:
+            raise ValueError(
+                "AUTH__BEARER_TOKEN must be set when AUTH__ENABLED is true"
+            )
+        return self
+
+
 class Settings(BaseSettings):
     """Main application settings."""
 
@@ -180,6 +256,28 @@ class Settings(BaseSettings):
         ge=1,
         description="Maximum number of GPU tasks allowed to run concurrently",
     )
+    MAX_UPLOAD_SIZE_MB: int = Field(
+        default=0,
+        ge=0,
+        description="Reject uploads larger than this many MB (0 = unlimited)",
+    )
+    MAX_QUEUED_GPU_REQUESTS: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "Cap on concurrent in-flight GPU requests across the API, split "
+            "between sync and async paths (0 = unlimited)"
+        ),
+    )
+    SYNC_GPU_QUOTA_FRACTION: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Fraction of MAX_QUEUED_GPU_REQUESTS reserved for the synchronous "
+            "(OpenAI-compatible) path; the async path gets the remainder"
+        ),
+    )
 
     # Nested settings
     database: DatabaseSettings = Field(default_factory=DatabaseSettings)
@@ -187,6 +285,8 @@ class Settings(BaseSettings):
     logging: LoggingSettings = Field(default_factory=LoggingSettings)
     callback: CallbackSettings = Field(default_factory=CallbackSettings)
     ssrf: SsrfSettings = Field(default_factory=SsrfSettings)
+    rate_limit: RateLimitSettings = Field(default_factory=RateLimitSettings)
+    auth: AuthSettings = Field(default_factory=AuthSettings)
 
     @field_validator("ENVIRONMENT", mode="before")
     @classmethod

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -265,8 +265,11 @@ class Settings(BaseSettings):
         default=0,
         ge=0,
         description=(
-            "Cap on concurrent in-flight GPU requests across the API, split "
-            "between sync and async paths (0 = unlimited)"
+            "Cap on concurrent in-flight transcription requests admitted across "
+            "the API, split between the sync and async paths (0 = unlimited). "
+            "Set >= 2 for a split whose combined cap equals this total; a value "
+            "of 1 admits up to 2 (one per path). Background GPU execution is "
+            "additionally bounded by MAX_CONCURRENT_GPU_TASKS."
         ),
     )
     SYNC_GPU_QUOTA_FRACTION: float = Field(

--- a/app/core/exceptions.py
+++ b/app/core/exceptions.py
@@ -592,6 +592,69 @@ class UnsupportedFileExtensionError(ValidationError):
         )
 
 
+# Authentication / throttling exceptions
+
+
+class AuthenticationError(ApplicationError):
+    """Bearer-token authentication failed or credentials were missing."""
+
+    def __init__(
+        self,
+        reason: str = "Missing or invalid authentication credentials",
+        correlation_id: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize the authentication error.
+
+        Args:
+            reason: Human-readable reason the request was rejected
+            correlation_id: Optional correlation ID for tracing
+        """
+        super().__init__(
+            message=f"Authentication failed: {reason}",
+            code="AUTHENTICATION_FAILED",
+            user_message=reason,
+            correlation_id=correlation_id,
+        )
+
+    @property
+    def error_type(self) -> str:
+        """Return an OpenAI-style error type."""
+        return "invalid_request_error"
+
+
+class ServiceOverloadedError(ApplicationError):
+    """Route-level concurrency cap exceeded; the service is temporarily busy."""
+
+    def __init__(
+        self,
+        scope: str,
+        retry_after: int = 1,
+        correlation_id: Optional[str] = None,
+    ) -> None:
+        """
+        Initialize the service overloaded error.
+
+        Args:
+            scope: Which request path was saturated (e.g. 'sync' or 'async')
+            retry_after: Suggested retry delay in seconds (sent as Retry-After)
+            correlation_id: Optional correlation ID for tracing
+        """
+        super().__init__(
+            message=f"Concurrency limit reached for {scope} requests",
+            code="SERVICE_OVERLOADED",
+            user_message="The service is busy processing other requests. Please retry shortly.",
+            correlation_id=correlation_id,
+            scope=scope,
+        )
+        self.retry_after = retry_after
+
+    @property
+    def error_type(self) -> str:
+        """Return an OpenAI-style error type."""
+        return "server_error"
+
+
 # Configuration-related exceptions
 
 

--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -1,0 +1,73 @@
+"""Per-caller rate limiting backed by slowapi.
+
+The :data:`limiter` is constructed once at import time, but its behaviour is
+driven by :func:`app.core.config.get_settings` on *every* request via the
+dynamic limit string, the key function, and the exemption predicate. This means
+toggling ``RATE_LIMIT__*`` environment variables takes effect without rebuilding
+the application (which keeps the feature configurable at runtime and testable).
+"""
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from starlette.requests import Request
+
+from app.core.config import RateLimitKeyStrategy, get_settings
+
+
+def rate_limit_key(request: Request) -> str:
+    """Return the rate-limit bucket key for the current request.
+
+    Honors ``RATE_LIMIT__KEY_STRATEGY``: ``bearer_token`` buckets by the
+    presented bearer token (falling back to the client IP when no usable token
+    is present), otherwise buckets by client IP.
+
+    Args:
+        request: The incoming request.
+
+    Returns:
+        A string key identifying the caller for rate-limit accounting.
+    """
+    settings = get_settings()
+    if settings.rate_limit.KEY_STRATEGY == RateLimitKeyStrategy.bearer_token:
+        authorization = request.headers.get("Authorization", "")
+        if authorization.lower().startswith("bearer "):
+            token = authorization[7:].strip()
+            if token:
+                return f"token:{token}"
+    return str(get_remote_address(request))
+
+
+def rate_limit_value() -> str:
+    """Return the slowapi limit string derived from current settings.
+
+    Combines the sustained per-minute budget with a short-term per-second burst
+    budget, e.g. ``"60/minute;10/second"``. Evaluated per request so config
+    changes take effect immediately.
+    """
+    rl = get_settings().rate_limit
+    return f"{rl.REQUESTS_PER_MINUTE}/minute;{rl.BURST}/second"
+
+
+def rate_limiting_disabled() -> bool:
+    """Return ``True`` when rate limiting is disabled.
+
+    Used as the slowapi ``exempt_when`` predicate so that, when disabled, the
+    limit is skipped entirely and no rate-limit headers are emitted.
+    """
+    return not get_settings().rate_limit.ENABLED
+
+
+limiter = Limiter(
+    key_func=rate_limit_key,
+    headers_enabled=True,
+    enabled=True,
+)
+
+
+def reset_rate_limiter() -> None:
+    """Clear the limiter's in-memory storage.
+
+    Intended for test isolation so accumulated request counts do not leak
+    between tests sharing the same process.
+    """
+    limiter.reset()

--- a/app/core/rate_limit.py
+++ b/app/core/rate_limit.py
@@ -2,9 +2,11 @@
 
 The :data:`limiter` is constructed once at import time, but its behaviour is
 driven by :func:`app.core.config.get_settings` on *every* request via the
-dynamic limit string, the key function, and the exemption predicate. This means
-toggling ``RATE_LIMIT__*`` environment variables takes effect without rebuilding
-the application (which keeps the feature configurable at runtime and testable).
+dynamic limit string, the key function, and the exemption predicate. Because
+``get_settings`` is ``lru_cache``-backed (loaded from the environment/``.env``
+at startup), the effective values are fixed for the life of the process; the
+per-request reads exist so the limit/strategy/enabled flag are evaluated
+together and so tests can clear the cache to re-read updated settings.
 """
 
 from slowapi import Limiter

--- a/app/docs/openapi.json
+++ b/app/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "whisperX REST service",
-    "description": "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.aac', '.oga', '.amr', '.mp3', '.awb', '.wma', '.wav', '.m4a', '.ogg'}\n\n    VIDEO_EXTENSIONS = {'.mov', '.avi', '.mkv', '.mp4', '.wmv'}\n\n    ",
+    "description": "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.ogg', '.mp3', '.amr', '.awb', '.oga', '.aac', '.m4a', '.wav', '.wma'}\n\n    VIDEO_EXTENSIONS = {'.mp4', '.mkv', '.mov', '.wmv', '.avi'}\n\n    ",
     "version": "0.0.1"
   },
   "paths": {
@@ -551,7 +551,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -1146,7 +1146,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -1252,7 +1252,7 @@
         "operationId": "get_all_tasks_status_task_all_get",
         "parameters": [
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -1311,7 +1311,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -1370,7 +1370,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -1823,7 +1823,7 @@
             "description": "Offset threshold for VAD (see pyannote.audio), reduce this if speech is not being detected."
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -1935,7 +1935,7 @@
             "description": "Return character-level alignments in the output json file"
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2078,7 +2078,7 @@
             "description": "Automatically store new speaker embeddings in the database (embeddings are computed automatically when enabled)"
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2138,7 +2138,7 @@
         "operationId": "4__Combine_Transcript_and_Diarization_result_service_combine_post",
         "parameters": [
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2198,7 +2198,7 @@
         "operationId": "Create_speaker_speakers_post",
         "parameters": [
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2297,7 +2297,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2360,7 +2360,7 @@
             "description": "Delete all speakers from this task"
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2419,7 +2419,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2476,7 +2476,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2543,7 +2543,7 @@
             }
           },
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2593,7 +2593,7 @@
         "operationId": "Search_speakers_speakers_search_post",
         "parameters": [
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2653,7 +2653,7 @@
         "operationId": "Identify_speaker_speakers_identify_post",
         "parameters": [
           {
-            "name": "authorization",
+            "name": "Authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2727,22 +2727,6 @@
               ],
               "title": "Authorization"
             }
-          },
-          {
-            "name": "authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
           }
         ],
         "responses": {
@@ -2802,22 +2786,6 @@
         "parameters": [
           {
             "name": "Authorization",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "anyOf": [
-                {
-                  "type": "string"
-                },
-                {
-                  "type": "null"
-                }
-              ],
-              "title": "Authorization"
-            }
-          },
-          {
-            "name": "authorization",
             "in": "header",
             "required": false,
             "schema": {

--- a/app/docs/openapi.json
+++ b/app/docs/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "whisperX REST service",
-    "description": "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.amr', '.mp3', '.awb', '.wav', '.oga', '.ogg', '.aac', '.wma', '.m4a'}\n\n    VIDEO_EXTENSIONS = {'.mkv', '.mp4', '.avi', '.mov', '.wmv'}\n\n    ",
+    "description": "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.aac', '.oga', '.amr', '.mp3', '.awb', '.wma', '.wav', '.m4a', '.ogg'}\n\n    VIDEO_EXTENSIONS = {'.mov', '.avi', '.mkv', '.mp4', '.wmv'}\n\n    ",
     "version": "0.0.1"
   },
   "paths": {
@@ -548,6 +548,22 @@
                 }
               ],
               "title": "Callback Url"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           }
         ],
@@ -1128,6 +1144,22 @@
               ],
               "title": "Callback Url"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "requestBody": {
@@ -1218,6 +1250,24 @@
         "summary": "Get All Tasks Status",
         "description": "Retrieve the status of all tasks.\n\nArgs:\n    service: Task management service dependency.\n\nReturns:\n    TaskListResponse: The status of all tasks.",
         "operationId": "get_all_tasks_status_task_all_get",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1225,6 +1275,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/TaskListResponse"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
                 }
               }
             }
@@ -1248,6 +1308,22 @@
             "schema": {
               "type": "string",
               "title": "Identifier"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           }
         ],
@@ -1291,6 +1367,22 @@
             "schema": {
               "type": "string",
               "title": "Identifier"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           }
         ],
@@ -1729,6 +1821,22 @@
               "title": "Vad Offset"
             },
             "description": "Offset threshold for VAD (see pyannote.audio), reduce this if speech is not being detected."
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "requestBody": {
@@ -1825,6 +1933,22 @@
               "title": "Return Char Alignments"
             },
             "description": "Return character-level alignments in the output json file"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "requestBody": {
@@ -1952,6 +2076,22 @@
               "title": "Auto Store Speakers"
             },
             "description": "Automatically store new speaker embeddings in the database (embeddings are computed automatically when enabled)"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "requestBody": {
@@ -1996,15 +2136,33 @@
         "summary": "4. Combine Transcript And Diarization Result",
         "description": "Combine a transcript with diarization results.\n\nArgs:\n    background_tasks (BackgroundTasks): Background tasks dependency.\n    aligned_transcript (UploadFile): Uploaded aligned transcript file.\n    diarization_result (UploadFile): Uploaded diarization result file.\n    repository (ITaskRepository): Task repository dependency.\n    file_service (FileService): File service dependency.\n    speaker_service (ISpeakerAssignmentService): Speaker assignment service dependency.\n\nReturns:\n    Response: Confirmation message of task queuing.",
         "operationId": "4__Combine_Transcript_and_Diarization_result_service_combine_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "multipart/form-data": {
               "schema": {
                 "$ref": "#/components/schemas/Body_4__Combine_Transcript_and_Diarization_result_service_combine_post"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2038,6 +2196,24 @@
         "summary": "Create Speaker",
         "description": "Create a new speaker embedding.",
         "operationId": "Create_speaker_speakers_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -2119,6 +2295,22 @@
               "default": 0,
               "title": "Offset"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "responses": {
@@ -2166,6 +2358,22 @@
               "title": "Task Id"
             },
             "description": "Delete all speakers from this task"
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "responses": {
@@ -2209,6 +2417,22 @@
               "type": "string",
               "title": "Uuid"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "responses": {
@@ -2249,6 +2473,22 @@
             "schema": {
               "type": "string",
               "title": "Uuid"
+            }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
             }
           }
         ],
@@ -2301,6 +2541,22 @@
               "type": "string",
               "title": "Uuid"
             }
+          },
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
           }
         ],
         "responses": {
@@ -2335,15 +2591,33 @@
         "summary": "Search Speakers",
         "description": "Search for similar speakers by embedding vector (cosine similarity).",
         "operationId": "Search_speakers_speakers_search_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SpeakerSearchRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2377,15 +2651,33 @@
         "summary": "Identify Speaker",
         "description": "Identify the best-matching speaker above threshold.",
         "operationId": "Identify_speaker_speakers_identify_post",
+        "parameters": [
+          {
+            "name": "authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          }
+        ],
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/SpeakerIdentifyRequest"
               }
             }
-          },
-          "required": true
+          }
         },
         "responses": {
           "200": {
@@ -2422,6 +2714,22 @@
         "parameters": [
           {
             "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "authorization",
             "in": "header",
             "required": false,
             "schema": {
@@ -2494,6 +2802,22 @@
         "parameters": [
           {
             "name": "Authorization",
+            "in": "header",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Authorization"
+            }
+          },
+          {
+            "name": "authorization",
             "in": "header",
             "required": false,
             "schema": {

--- a/app/docs/openapi.yaml
+++ b/app/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: whisperX REST service
-  description: "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.aac', '.oga', '.amr', '.mp3', '.awb', '.wma', '.wav', '.m4a', '.ogg'}\n\n    VIDEO_EXTENSIONS = {'.mov', '.avi', '.mkv', '.mp4', '.wmv'}\n\n    "
+  description: "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.ogg', '.mp3', '.amr', '.awb', '.oga', '.aac', '.m4a', '.wav', '.wma'}\n\n    VIDEO_EXTENSIONS = {'.mp4', '.mkv', '.mov', '.wmv', '.avi'}\n\n    "
   version: 0.0.1
 paths:
   /speech-to-text:
@@ -411,7 +411,7 @@ paths:
                 maxLength: 2083
               - type: 'null'
             title: Callback Url
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -845,7 +845,7 @@ paths:
                 maxLength: 2083
               - type: 'null'
             title: Callback Url
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -908,7 +908,7 @@ paths:
       description: "Retrieve the status of all tasks.\n\nArgs:\n    service: Task management service dependency.\n\nReturns:\n    TaskListResponse: The status of all tasks."
       operationId: get_all_tasks_status_task_all_get
       parameters:
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -943,7 +943,7 @@ paths:
           schema:
             type: string
             title: Identifier
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -978,7 +978,7 @@ paths:
           schema:
             type: string
             title: Identifier
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1321,7 +1321,7 @@ paths:
             default: 0.363
             title: Vad Offset
           description: Offset threshold for VAD (see pyannote.audio), reduce this if speech is not being detected.
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1391,7 +1391,7 @@ paths:
             default: false
             title: Return Char Alignments
           description: Return character-level alignments in the output json file
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1481,7 +1481,7 @@ paths:
             default: false
             title: Auto Store Speakers
           description: Automatically store new speaker embeddings in the database (embeddings are computed automatically when enabled)
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1516,7 +1516,7 @@ paths:
       description: "Combine a transcript with diarization results.\n\nArgs:\n    background_tasks (BackgroundTasks): Background tasks dependency.\n    aligned_transcript (UploadFile): Uploaded aligned transcript file.\n    diarization_result (UploadFile): Uploaded diarization result file.\n    repository (ITaskRepository): Task repository dependency.\n    file_service (FileService): File service dependency.\n    speaker_service (ISpeakerAssignmentService): Speaker assignment service dependency.\n\nReturns:\n    Response: Confirmation message of task queuing."
       operationId: 4__Combine_Transcript_and_Diarization_result_service_combine_post
       parameters:
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1551,7 +1551,7 @@ paths:
       description: Create a new speaker embedding.
       operationId: Create_speaker_speakers_post
       parameters:
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1612,7 +1612,7 @@ paths:
             minimum: 0
             default: 0
             title: Offset
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1651,7 +1651,7 @@ paths:
             description: Delete all speakers from this task
             title: Task Id
           description: Delete all speakers from this task
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1686,7 +1686,7 @@ paths:
           schema:
             type: string
             title: Uuid
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1720,7 +1720,7 @@ paths:
           schema:
             type: string
             title: Uuid
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1760,7 +1760,7 @@ paths:
           schema:
             type: string
             title: Uuid
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1789,7 +1789,7 @@ paths:
       description: Search for similar speakers by embedding vector (cosine similarity).
       operationId: Search_speakers_speakers_search_post
       parameters:
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1824,7 +1824,7 @@ paths:
       description: Identify the best-matching speaker above threshold.
       operationId: Identify_speaker_speakers_identify_post
       parameters:
-        - name: authorization
+        - name: Authorization
           in: header
           required: false
           schema:
@@ -1874,14 +1874,6 @@ paths:
               - type: string
               - type: 'null'
             title: Authorization
-        - name: authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            title: Authorization
       responses:
         '200':
           description: Transcript in the requested format.
@@ -1922,14 +1914,6 @@ paths:
       operationId: create_translation_v1_audio_translations_post
       parameters:
         - name: Authorization
-          in: header
-          required: false
-          schema:
-            anyOf:
-              - type: string
-              - type: 'null'
-            title: Authorization
-        - name: authorization
           in: header
           required: false
           schema:

--- a/app/docs/openapi.yaml
+++ b/app/docs/openapi.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: whisperX REST service
-  description: "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.amr', '.mp3', '.awb', '.wav', '.oga', '.ogg', '.aac', '.wma', '.m4a'}\n\n    VIDEO_EXTENSIONS = {'.mkv', '.mp4', '.avi', '.mov', '.wmv'}\n\n    "
+  description: "\n    # whisperX RESTful API\n\n    Welcome to the whisperX RESTful API! This API provides a suite of audio processing services to enhance and analyze your audio content.\n\n    ## Documentation:\n\n    For detailed information on request and response formats, consult the [WhisperX Documentation](https://github.com/m-bain/whisperX).\n\n    ## Services:\n\n    Speech-2-Text provides a suite of audio processing services to enhance and analyze your audio content. The following services are available:\n\n    1. Transcribe: Transcribe an audio/video  file into text.\n    2. Align: Align the transcript to the audio/video file.\n    3. Diarize: Diarize an audio/video file into speakers.\n    4. Combine Transcript and Diarization: Combine the transcript and diarization results.\n\n    ## Supported file extensions:\n    AUDIO_EXTENSIONS = {'.aac', '.oga', '.amr', '.mp3', '.awb', '.wma', '.wav', '.m4a', '.ogg'}\n\n    VIDEO_EXTENSIONS = {'.mov', '.avi', '.mkv', '.mp4', '.wmv'}\n\n    "
   version: 0.0.1
 paths:
   /speech-to-text:
@@ -411,6 +411,14 @@ paths:
                 maxLength: 2083
               - type: 'null'
             title: Callback Url
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -837,6 +845,14 @@ paths:
                 maxLength: 2083
               - type: 'null'
             title: Callback Url
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -891,6 +907,15 @@ paths:
       summary: Get All Tasks Status
       description: "Retrieve the status of all tasks.\n\nArgs:\n    service: Task management service dependency.\n\nReturns:\n    TaskListResponse: The status of all tasks."
       operationId: get_all_tasks_status_task_all_get
+      parameters:
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -898,6 +923,12 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/TaskListResponse'
+        '422':
+          description: Validation Error
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HTTPValidationError'
   /task/{identifier}:
     get:
       tags:
@@ -912,6 +943,14 @@ paths:
           schema:
             type: string
             title: Identifier
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -939,6 +978,14 @@ paths:
           schema:
             type: string
             title: Identifier
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -1274,6 +1321,14 @@ paths:
             default: 0.363
             title: Vad Offset
           description: Offset threshold for VAD (see pyannote.audio), reduce this if speech is not being detected.
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -1336,6 +1391,14 @@ paths:
             default: false
             title: Return Char Alignments
           description: Return character-level alignments in the output json file
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -1418,6 +1481,14 @@ paths:
             default: false
             title: Auto Store Speakers
           description: Automatically store new speaker embeddings in the database (embeddings are computed automatically when enabled)
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -1444,12 +1515,21 @@ paths:
       summary: 4. Combine Transcript And Diarization Result
       description: "Combine a transcript with diarization results.\n\nArgs:\n    background_tasks (BackgroundTasks): Background tasks dependency.\n    aligned_transcript (UploadFile): Uploaded aligned transcript file.\n    diarization_result (UploadFile): Uploaded diarization result file.\n    repository (ITaskRepository): Task repository dependency.\n    file_service (FileService): File service dependency.\n    speaker_service (ISpeakerAssignmentService): Speaker assignment service dependency.\n\nReturns:\n    Response: Confirmation message of task queuing."
       operationId: 4__Combine_Transcript_and_Diarization_result_service_combine_post
+      parameters:
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
+        required: true
         content:
           multipart/form-data:
             schema:
               $ref: '#/components/schemas/Body_4__Combine_Transcript_and_Diarization_result_service_combine_post'
-        required: true
       responses:
         '200':
           description: Successful Response
@@ -1470,6 +1550,15 @@ paths:
       summary: Create Speaker
       description: Create a new speaker embedding.
       operationId: Create_speaker_speakers_post
+      parameters:
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -1523,6 +1612,14 @@ paths:
             minimum: 0
             default: 0
             title: Offset
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -1554,6 +1651,14 @@ paths:
             description: Delete all speakers from this task
             title: Task Id
           description: Delete all speakers from this task
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -1581,6 +1686,14 @@ paths:
           schema:
             type: string
             title: Uuid
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -1607,6 +1720,14 @@ paths:
           schema:
             type: string
             title: Uuid
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
         required: true
         content:
@@ -1639,6 +1760,14 @@ paths:
           schema:
             type: string
             title: Uuid
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       responses:
         '200':
           description: Successful Response
@@ -1659,12 +1788,21 @@ paths:
       summary: Search Speakers
       description: Search for similar speakers by embedding vector (cosine similarity).
       operationId: Search_speakers_speakers_search_post
+      parameters:
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SpeakerSearchRequest'
-        required: true
       responses:
         '200':
           description: Successful Response
@@ -1685,12 +1823,21 @@ paths:
       summary: Identify Speaker
       description: Identify the best-matching speaker above threshold.
       operationId: Identify_speaker_speakers_identify_post
+      parameters:
+        - name: authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
       requestBody:
+        required: true
         content:
           application/json:
             schema:
               $ref: '#/components/schemas/SpeakerIdentifyRequest'
-        required: true
       responses:
         '200':
           description: Successful Response
@@ -1720,6 +1867,14 @@ paths:
       operationId: create_transcription_v1_audio_transcriptions_post
       parameters:
         - name: Authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
+        - name: authorization
           in: header
           required: false
           schema:
@@ -1767,6 +1922,14 @@ paths:
       operationId: create_translation_v1_audio_translations_post
       parameters:
         - name: Authorization
+          in: header
+          required: false
+          schema:
+            anyOf:
+              - type: string
+              - type: 'null'
+            title: Authorization
+        - name: authorization
           in: header
           required: false
           schema:

--- a/app/main.py
+++ b/app/main.py
@@ -40,8 +40,9 @@ import uuid  # noqa: E402
 from contextlib import asynccontextmanager  # noqa: E402
 
 from dotenv import load_dotenv  # noqa: E402
-from fastapi import FastAPI, status  # noqa: E402
+from fastapi import Depends, FastAPI, status  # noqa: E402
 from fastapi.responses import JSONResponse, RedirectResponse  # noqa: E402
+from slowapi.errors import RateLimitExceeded  # noqa: E402
 from sqlalchemy import text  # noqa: E402
 from starlette.types import ASGIApp, Receive, Scope, Send  # noqa: E402
 
@@ -70,22 +71,34 @@ from app.api import (  # noqa: E402
     task_router,
 )
 from app.api.exception_handlers import (  # noqa: E402
+    authentication_error_handler,
     domain_error_handler,
     generic_error_handler,
     infrastructure_error_handler,
+    rate_limit_exceeded_handler,
+    service_overloaded_handler,
     speaker_not_found_handler,
     task_not_found_handler,
     validation_error_handler,
 )
+from app.api.middleware import MaxUploadSizeMiddleware  # noqa: E402
+from app.api.security import (  # noqa: E402
+    enforce_async_gpu_quota,
+    enforce_sync_gpu_quota,
+    verify_bearer_token,
+)
 from app.core.config import Config, get_settings  # noqa: E402
 from app.core.container import Container  # noqa: E402
 from app.core.exceptions import (  # noqa: E402
+    AuthenticationError,
     DomainError,
     InfrastructureError,
+    ServiceOverloadedError,
     SpeakerNotFoundError,
     TaskNotFoundError,
     ValidationError,
 )
+from app.core.rate_limit import limiter  # noqa: E402
 from app.docs import generate_db_schema, save_openapi_json  # noqa: E402
 from app.infrastructure.database import Base, async_engine, sync_engine  # noqa: E402
 
@@ -196,20 +209,38 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+# Expose the rate limiter so its exception handler can inject headers.
+app.state.limiter = limiter
+
 # Register exception handlers
 app.add_exception_handler(TaskNotFoundError, task_not_found_handler)
 app.add_exception_handler(SpeakerNotFoundError, speaker_not_found_handler)
 app.add_exception_handler(ValidationError, validation_error_handler)
 app.add_exception_handler(DomainError, domain_error_handler)
 app.add_exception_handler(InfrastructureError, infrastructure_error_handler)
+app.add_exception_handler(AuthenticationError, authentication_error_handler)
+app.add_exception_handler(ServiceOverloadedError, service_overloaded_handler)
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 app.add_exception_handler(Exception, generic_error_handler)
 
-# Include routers
-app.include_router(stt_router)
-app.include_router(task_router)
-app.include_router(service_router)
-app.include_router(speaker_router)
-app.include_router(openai_compat_router)
+# Include routers.
+# Bearer-token auth (when enabled) applies API-wide; route-level concurrency
+# gates protect the GPU-bound paths: the async background path (stt/service)
+# and the synchronous OpenAI-compatible path get separate budgets.
+app.include_router(
+    stt_router,
+    dependencies=[Depends(verify_bearer_token), Depends(enforce_async_gpu_quota)],
+)
+app.include_router(task_router, dependencies=[Depends(verify_bearer_token)])
+app.include_router(
+    service_router,
+    dependencies=[Depends(verify_bearer_token), Depends(enforce_async_gpu_quota)],
+)
+app.include_router(speaker_router, dependencies=[Depends(verify_bearer_token)])
+app.include_router(
+    openai_compat_router,
+    dependencies=[Depends(verify_bearer_token), Depends(enforce_sync_gpu_quota)],
+)
 
 
 class RequestContextMiddleware:
@@ -264,6 +295,9 @@ class RequestContextMiddleware:
 
 
 app.add_middleware(RequestContextMiddleware)
+# Added last so it is the outermost middleware: oversized uploads are rejected
+# with HTTP 413 before the body is buffered or any downstream work begins.
+app.add_middleware(MaxUploadSizeMiddleware)
 
 
 @app.get("/", include_in_schema=False)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "huggingface-hub<0.36.0",
     "python-json-logger>=4.0.0",
     "requests>=2.33.0",
+    "slowapi>=0.1.9",
 ]
 
 [project.optional-dependencies]

--- a/tests/e2e/test_api_protection.py
+++ b/tests/e2e/test_api_protection.py
@@ -1,0 +1,220 @@
+"""End-to-end tests for API-wide protection (issue #533).
+
+Covers upload-size cap (413), per-caller rate limiting (429), route-level
+concurrency caps (503), and bearer-token auth (401) on one synchronous endpoint
+(``/v1/audio/transcriptions``) and one asynchronous endpoint
+(``/service/transcribe``), plus the no-op-by-default behavior.
+
+All features read settings per request, so each test toggles the relevant
+``*`` environment variables, clears the cached settings/gates, and resets the
+rate limiter — no app rebuild required.
+"""
+
+from collections.abc import Generator
+from typing import Any
+
+import pytest
+from _pytest.monkeypatch import MonkeyPatch
+from dependency_injector import providers
+from fastapi.testclient import TestClient
+from unittest.mock import patch
+
+import app.main as main_module
+from app.api.dependencies import get_task_repository
+from app.core.concurrency import (
+    get_async_concurrency_gate,
+    get_sync_concurrency_gate,
+)
+from app.core.config import get_settings
+from app.core.rate_limit import reset_rate_limiter
+from app.domain.entities.task import Task as DomainTask
+from tests.mocks import MockAlignmentService, MockTranscriptionService
+
+SYNC_ENDPOINT = "/v1/audio/transcriptions"
+ASYNC_ENDPOINT = "/service/transcribe"
+AUDIO_BYTES = b"dummy-audio-bytes"
+
+
+class _FakeTaskRepository:
+    """In-memory task repository so protection tests never touch the database."""
+
+    def __init__(self) -> None:
+        self.added: list[DomainTask] = []
+        self.updates: list[tuple[str, dict[str, Any]]] = []
+
+    async def add(self, task: DomainTask) -> str:
+        self.added.append(task)
+        return task.uuid
+
+    async def update(self, identifier: str, update_data: dict[str, Any]) -> None:
+        self.updates.append((identifier, update_data))
+
+    async def get_by_id(self, identifier: str) -> DomainTask | None:
+        return None
+
+    async def get_all(self) -> list[DomainTask]:
+        return list(self.added)
+
+    async def delete(self, identifier: str) -> bool:
+        return True
+
+
+def _reset_runtime_caches() -> None:
+    """Reset cached settings, concurrency gates, and rate-limit storage."""
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+    reset_rate_limiter()
+
+
+@pytest.fixture
+def protected_client(monkeypatch: MonkeyPatch) -> Generator[TestClient, None, None]:
+    """A TestClient with mocked ML services and DB-free, audio-free success paths."""
+    container = main_module.container
+    container.transcription_service.override(
+        providers.Object(MockTranscriptionService())
+    )
+    container.alignment_service.override(providers.Object(MockAlignmentService()))
+
+    fake_repo = _FakeTaskRepository()
+    main_module.app.dependency_overrides[get_task_repository] = lambda: fake_repo
+
+    # Make audio decoding and background processing no-ops so the success path is
+    # fast and deterministic without ffmpeg or the database.
+    for module in ("app.api.openai_compat_api", "app.api.audio_services_api"):
+        monkeypatch.setattr(f"{module}.process_audio_file", lambda *_a, **_k: "AUDIO")
+        monkeypatch.setattr(f"{module}.get_audio_duration", lambda *_a, **_k: 1.0)
+    monkeypatch.setattr(
+        "app.api.audio_services_api.process_transcribe", lambda *_a, **_k: None
+    )
+
+    _reset_runtime_caches()
+
+    with (
+        patch("app.main.save_openapi_json"),
+        patch("app.main.generate_db_schema"),
+        TestClient(main_module.app, follow_redirects=False) as client,
+    ):
+        yield client
+
+    main_module.app.dependency_overrides.pop(get_task_repository, None)
+    container.transcription_service.reset_override()
+    container.alignment_service.reset_override()
+    _reset_runtime_caches()
+
+
+def _post(
+    client: TestClient, endpoint: str, headers: dict[str, str] | None = None
+) -> Any:
+    """Post a small valid multipart transcription request to ``endpoint``."""
+    files: list[tuple[str, Any]] = [("file", ("audio.mp3", AUDIO_BYTES, "audio/mpeg"))]
+    if endpoint == SYNC_ENDPOINT:
+        files.append(("model", (None, "whisper-1")))
+    return client.post(endpoint, files=files, headers=headers)
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("endpoint", [SYNC_ENDPOINT, ASYNC_ENDPOINT])
+def test_no_protection_by_default(protected_client: TestClient, endpoint: str) -> None:
+    """With all features off (defaults), requests succeed unprotected."""
+    response = _post(protected_client, endpoint)
+    assert response.status_code == 200
+
+
+# --- Upload size cap (413) ---------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("endpoint", [SYNC_ENDPOINT, ASYNC_ENDPOINT])
+def test_oversize_upload_rejected(
+    protected_client: TestClient, monkeypatch: MonkeyPatch, endpoint: str
+) -> None:
+    """A body exceeding MAX_UPLOAD_SIZE_MB is rejected with 413."""
+    monkeypatch.setenv("MAX_UPLOAD_SIZE_MB", "1")
+    get_settings.cache_clear()
+
+    response = protected_client.post(endpoint, content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 413
+    assert response.json()["error"]["code"] == "REQUEST_TOO_LARGE"
+
+
+# --- Rate limiting (429) -----------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("endpoint", [SYNC_ENDPOINT, ASYNC_ENDPOINT])
+def test_rate_limit_trips_after_budget(
+    protected_client: TestClient, monkeypatch: MonkeyPatch, endpoint: str
+) -> None:
+    """Exceeding the per-minute/burst budget returns 429 with Retry-After."""
+    monkeypatch.setenv("RATE_LIMIT__ENABLED", "true")
+    monkeypatch.setenv("RATE_LIMIT__REQUESTS_PER_MINUTE", "1")
+    monkeypatch.setenv("RATE_LIMIT__BURST", "1")
+    _reset_runtime_caches()
+
+    first = _post(protected_client, endpoint)
+    assert first.status_code == 200
+
+    second = _post(protected_client, endpoint)
+    assert second.status_code == 429
+    assert "Retry-After" in second.headers
+    assert second.json()["error"]["code"] == "RATE_LIMIT_EXCEEDED"
+
+
+# --- Route concurrency cap (503) ---------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize(
+    ("endpoint", "gate_getter"),
+    [
+        (SYNC_ENDPOINT, get_sync_concurrency_gate),
+        (ASYNC_ENDPOINT, get_async_concurrency_gate),
+    ],
+)
+def test_concurrency_cap_trips_when_full(
+    protected_client: TestClient,
+    monkeypatch: MonkeyPatch,
+    endpoint: str,
+    gate_getter: Any,
+) -> None:
+    """When the path's concurrency budget is exhausted, requests get 503."""
+    monkeypatch.setenv("MAX_QUEUED_GPU_REQUESTS", "2")
+    monkeypatch.setenv("SYNC_GPU_QUOTA_FRACTION", "0.5")
+    _reset_runtime_caches()
+
+    gate = gate_getter()  # capacity 1 for each path
+    assert gate.acquire() is True  # occupy the only slot
+    try:
+        response = _post(protected_client, endpoint)
+    finally:
+        gate.release()
+
+    assert response.status_code == 503
+    assert "Retry-After" in response.headers
+    assert response.json()["error"]["code"] == "SERVICE_OVERLOADED"
+
+
+# --- Bearer-token auth (401) -------------------------------------------------
+
+
+@pytest.mark.e2e
+@pytest.mark.parametrize("endpoint", [SYNC_ENDPOINT, ASYNC_ENDPOINT])
+def test_auth_required_when_enabled(
+    protected_client: TestClient, monkeypatch: MonkeyPatch, endpoint: str
+) -> None:
+    """With auth enabled, a missing token is rejected and a valid token passes."""
+    monkeypatch.setenv("AUTH__ENABLED", "true")
+    monkeypatch.setenv("AUTH__BEARER_TOKEN", "s3cret")
+    get_settings.cache_clear()
+
+    missing = _post(protected_client, endpoint)
+    assert missing.status_code == 401
+    assert missing.headers["WWW-Authenticate"] == "Bearer"
+    assert missing.json()["error"]["code"] == "AUTHENTICATION_FAILED"
+
+    authorized = _post(
+        protected_client, endpoint, headers={"Authorization": "Bearer s3cret"}
+    )
+    assert authorized.status_code == 200

--- a/tests/unit/api/test_exception_handlers.py
+++ b/tests/unit/api/test_exception_handlers.py
@@ -4,16 +4,23 @@ import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from slowapi.errors import RateLimitExceeded
+
 from app.api.exception_handlers import (
+    authentication_error_handler,
     domain_error_handler,
     generic_error_handler,
     infrastructure_error_handler,
+    rate_limit_exceeded_handler,
+    service_overloaded_handler,
     task_not_found_handler,
     validation_error_handler,
 )
 from app.core.exceptions import (
+    AuthenticationError,
     DomainError,
     InfrastructureError,
+    ServiceOverloadedError,
     TaskNotFoundError,
     TranscriptionFailedError,
     UnsupportedFileExtensionError,
@@ -28,6 +35,9 @@ app.add_exception_handler(TaskNotFoundError, task_not_found_handler)
 app.add_exception_handler(ValidationError, validation_error_handler)
 app.add_exception_handler(DomainError, domain_error_handler)
 app.add_exception_handler(InfrastructureError, infrastructure_error_handler)
+app.add_exception_handler(AuthenticationError, authentication_error_handler)
+app.add_exception_handler(ServiceOverloadedError, service_overloaded_handler)
+app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 app.add_exception_handler(Exception, generic_error_handler)
 
 
@@ -76,6 +86,30 @@ async def raise_generic_error() -> None:
     raise ValueError("Unexpected error")
 
 
+@app.get("/test/authentication-error")
+async def raise_authentication_error() -> None:
+    """Raise AuthenticationError."""
+    raise AuthenticationError(reason="Invalid bearer token")
+
+
+@app.get("/test/service-overloaded")
+async def raise_service_overloaded() -> None:
+    """Raise ServiceOverloadedError."""
+    raise ServiceOverloadedError(scope="sync", retry_after=3)
+
+
+@app.get("/test/rate-limit-exceeded")
+async def raise_rate_limit_exceeded() -> None:
+    """Raise slowapi RateLimitExceeded."""
+    from limits import parse
+    from slowapi.wrappers import Limit
+
+    limit = Limit(
+        parse("1/minute"), lambda: "key", None, False, None, None, None, 1, True
+    )
+    raise RateLimitExceeded(limit)
+
+
 # Test client
 client = TestClient(app, raise_server_exceptions=False)
 
@@ -115,6 +149,45 @@ def test_unsupported_file_extension_handler() -> None:
     assert "error" in data
     assert data["error"]["code"] == "UNSUPPORTED_FILE_EXTENSION"
     assert ".txt" in data["error"]["message"]
+    assert "correlation_id" in data["error"]
+
+
+@pytest.mark.unit
+def test_authentication_error_handler() -> None:
+    """Test AuthenticationError handler returns 401 with WWW-Authenticate."""
+    response = client.get("/test/authentication-error")
+
+    assert response.status_code == 401
+    assert response.headers["WWW-Authenticate"] == "Bearer"
+    data = response.json()
+    assert data["error"]["code"] == "AUTHENTICATION_FAILED"
+    assert data["error"]["type"] == "invalid_request_error"
+    assert "correlation_id" in data["error"]
+
+
+@pytest.mark.unit
+def test_service_overloaded_handler() -> None:
+    """Test ServiceOverloadedError handler returns 503 with Retry-After."""
+    response = client.get("/test/service-overloaded")
+
+    assert response.status_code == 503
+    assert response.headers["Retry-After"] == "3"
+    data = response.json()
+    assert data["error"]["code"] == "SERVICE_OVERLOADED"
+    assert data["error"]["type"] == "server_error"
+    assert data["error"]["scope"] == "sync"
+
+
+@pytest.mark.unit
+def test_rate_limit_exceeded_handler() -> None:
+    """Test RateLimitExceeded handler returns 429 with OpenAI-style envelope."""
+    response = client.get("/test/rate-limit-exceeded")
+
+    assert response.status_code == 429
+    data = response.json()
+    assert data["error"]["code"] == "RATE_LIMIT_EXCEEDED"
+    assert data["error"]["type"] == "rate_limit_error"
+    assert "1 per 1 minute" in data["error"]["message"]
     assert "correlation_id" in data["error"]
 
 

--- a/tests/unit/api/test_security.py
+++ b/tests/unit/api/test_security.py
@@ -1,0 +1,151 @@
+"""Unit tests for security dependencies (auth + concurrency gates)."""
+
+import os
+from collections.abc import AsyncGenerator, Generator
+
+import pytest
+
+from app.api.security import (
+    enforce_async_gpu_quota,
+    enforce_sync_gpu_quota,
+    verify_bearer_token,
+)
+from app.core.concurrency import (
+    get_async_concurrency_gate,
+    get_sync_concurrency_gate,
+)
+from app.core.config import get_settings
+from app.core.exceptions import AuthenticationError, ServiceOverloadedError
+
+
+@pytest.fixture
+def reset_auth_env() -> Generator[None, None, None]:
+    """Snapshot and restore AUTH__ env vars around each test."""
+    saved = {
+        key: os.environ.get(key) for key in ("AUTH__ENABLED", "AUTH__BEARER_TOKEN")
+    }
+    get_settings.cache_clear()
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def reset_gate_env() -> Generator[None, None, None]:
+    """Snapshot/restore queue cap env and clear cached gates around each test."""
+    saved = {
+        key: os.environ.get(key)
+        for key in ("MAX_QUEUED_GPU_REQUESTS", "SYNC_GPU_QUOTA_FRACTION")
+    }
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+
+@pytest.mark.unit
+def test_auth_disabled_is_noop(reset_auth_env: None) -> None:
+    """When auth is disabled, any (or no) credential is accepted."""
+    os.environ.pop("AUTH__ENABLED", None)
+    get_settings.cache_clear()
+
+    assert verify_bearer_token(None) is None
+    assert verify_bearer_token("Bearer anything") is None
+
+
+@pytest.mark.unit
+def test_auth_enabled_accepts_valid_token(reset_auth_env: None) -> None:
+    """A matching bearer token passes when auth is enabled."""
+    os.environ["AUTH__ENABLED"] = "true"
+    os.environ["AUTH__BEARER_TOKEN"] = "s3cret"
+    get_settings.cache_clear()
+
+    assert verify_bearer_token("Bearer s3cret") is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    "header",
+    [None, "", "Token s3cret", "Bearer", "Bearer wrong"],
+)
+def test_auth_enabled_rejects_bad_token(
+    reset_auth_env: None, header: str | None
+) -> None:
+    """Missing or non-matching credentials are rejected with 401 semantics."""
+    os.environ["AUTH__ENABLED"] = "true"
+    os.environ["AUTH__BEARER_TOKEN"] = "s3cret"
+    get_settings.cache_clear()
+
+    with pytest.raises(AuthenticationError):
+        verify_bearer_token(header)
+
+
+async def _drain(gen: AsyncGenerator[None, None]) -> None:
+    """Acquire then release a concurrency-gate dependency generator."""
+    await gen.__anext__()
+    with pytest.raises(StopAsyncIteration):
+        await gen.__anext__()
+
+
+@pytest.mark.unit
+async def test_sync_quota_releases_slot(reset_gate_env: None) -> None:
+    """The sync dependency acquires and then releases its slot."""
+    os.environ["MAX_QUEUED_GPU_REQUESTS"] = "2"
+    os.environ["SYNC_GPU_QUOTA_FRACTION"] = "0.5"
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+    await _drain(enforce_sync_gpu_quota())
+    # Slot was released, so the gate is fully available again.
+    gate = get_sync_concurrency_gate()
+    assert gate.acquire() is True
+    gate.release()
+
+
+@pytest.mark.unit
+async def test_sync_quota_rejects_when_full(reset_gate_env: None) -> None:
+    """The sync dependency raises 503 when no slot is available."""
+    os.environ["MAX_QUEUED_GPU_REQUESTS"] = "2"
+    os.environ["SYNC_GPU_QUOTA_FRACTION"] = "0.5"
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+    gate = get_sync_concurrency_gate()  # capacity 1
+    assert gate.acquire() is True  # exhaust the only slot
+
+    gen = enforce_sync_gpu_quota()
+    with pytest.raises(ServiceOverloadedError):
+        await gen.__anext__()
+    gate.release()
+
+
+@pytest.mark.unit
+async def test_async_quota_rejects_when_full(reset_gate_env: None) -> None:
+    """The async dependency raises 503 when no slot is available."""
+    os.environ["MAX_QUEUED_GPU_REQUESTS"] = "2"
+    os.environ["SYNC_GPU_QUOTA_FRACTION"] = "0.5"
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+    gate = get_async_concurrency_gate()  # capacity 1
+    assert gate.acquire() is True
+
+    gen = enforce_async_gpu_quota()
+    with pytest.raises(ServiceOverloadedError):
+        await gen.__anext__()
+    gate.release()

--- a/tests/unit/api/test_upload_limit_middleware.py
+++ b/tests/unit/api/test_upload_limit_middleware.py
@@ -1,0 +1,125 @@
+"""Unit tests for the upload size cap middleware."""
+
+import os
+from collections.abc import Generator
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from app.api.middleware import MaxUploadSizeMiddleware
+from app.core.config import get_settings
+
+
+def _build_client() -> TestClient:
+    """Build a minimal app wrapped with the upload size middleware."""
+    app = FastAPI()
+    app.add_middleware(MaxUploadSizeMiddleware)
+
+    @app.post("/echo")
+    async def echo(request: Request) -> dict[str, int]:
+        body = await request.body()
+        return {"received": len(body)}
+
+    @app.get("/ping")
+    async def ping() -> dict[str, str]:
+        return {"status": "ok"}
+
+    return TestClient(app)
+
+
+@pytest.fixture
+def reset_settings() -> Generator[None, None, None]:
+    """Clear the settings cache around each test that mutates env vars."""
+    get_settings.cache_clear()
+    original = os.environ.get("MAX_UPLOAD_SIZE_MB")
+    yield
+    if original is None:
+        os.environ.pop("MAX_UPLOAD_SIZE_MB", None)
+    else:
+        os.environ["MAX_UPLOAD_SIZE_MB"] = original
+    get_settings.cache_clear()
+
+
+@pytest.mark.unit
+def test_oversize_upload_rejected_with_413(reset_settings: None) -> None:
+    """A body larger than the cap is rejected with 413 before reaching the route."""
+    os.environ["MAX_UPLOAD_SIZE_MB"] = "1"
+    get_settings.cache_clear()
+    client = _build_client()
+
+    response = client.post("/echo", content=b"x" * (2 * 1024 * 1024))
+
+    assert response.status_code == 413
+    body = response.json()
+    assert body["error"]["code"] == "REQUEST_TOO_LARGE"
+    assert body["error"]["type"] == "invalid_request_error"
+
+
+@pytest.mark.unit
+def test_upload_within_cap_passes(reset_settings: None) -> None:
+    """A body within the cap reaches the route handler."""
+    os.environ["MAX_UPLOAD_SIZE_MB"] = "1"
+    get_settings.cache_clear()
+    client = _build_client()
+
+    response = client.post("/echo", content=b"x" * 1024)
+
+    assert response.status_code == 200
+    assert response.json()["received"] == 1024
+
+
+@pytest.mark.unit
+def test_zero_cap_is_unlimited(reset_settings: None) -> None:
+    """A cap of 0 disables enforcement (default no-op behavior)."""
+    os.environ["MAX_UPLOAD_SIZE_MB"] = "0"
+    get_settings.cache_clear()
+    client = _build_client()
+
+    response = client.post("/echo", content=b"x" * (3 * 1024 * 1024))
+
+    assert response.status_code == 200
+
+
+@pytest.mark.unit
+def test_get_requests_not_checked(reset_settings: None) -> None:
+    """GET requests bypass the body-size check."""
+    os.environ["MAX_UPLOAD_SIZE_MB"] = "1"
+    get_settings.cache_clear()
+    client = _build_client()
+
+    response = client.get("/ping")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.unit
+async def test_malformed_content_length_passes_through(reset_settings: None) -> None:
+    """A non-numeric Content-Length is treated as unknown and not rejected."""
+    os.environ["MAX_UPLOAD_SIZE_MB"] = "1"
+    get_settings.cache_clear()
+
+    reached: list[str] = []
+
+    async def inner(scope: dict, receive: object, send: object) -> None:
+        reached.append("inner")
+
+    middleware = MaxUploadSizeMiddleware(inner)
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "headers": [(b"content-length", b"not-a-number")],
+    }
+
+    async def receive() -> dict:
+        return {"type": "http.request", "body": b""}
+
+    sent: list[dict] = []
+
+    async def send(message: dict) -> None:
+        sent.append(message)
+
+    await middleware(scope, receive, send)
+
+    assert reached == ["inner"]
+    assert sent == []

--- a/tests/unit/core/test_concurrency.py
+++ b/tests/unit/core/test_concurrency.py
@@ -1,0 +1,99 @@
+"""Unit tests for route-level concurrency gates."""
+
+import os
+from collections.abc import Generator
+
+import pytest
+
+from app.core.concurrency import (
+    ConcurrencyGate,
+    compute_quota_split,
+    get_async_concurrency_gate,
+    get_sync_concurrency_gate,
+)
+from app.core.config import get_settings
+
+
+@pytest.fixture
+def reset_gates() -> Generator[None, None, None]:
+    """Clear cached gates and quota env vars around each test."""
+    saved = {
+        key: os.environ.get(key)
+        for key in ("MAX_QUEUED_GPU_REQUESTS", "SYNC_GPU_QUOTA_FRACTION")
+    }
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("total", "fraction", "expected"),
+    [
+        (0, 0.5, (0, 0)),
+        (20, 0.5, (10, 10)),
+        (20, 0.25, (5, 15)),
+        (1, 0.5, (1, 1)),
+        (10, 0.0, (1, 9)),
+        (10, 1.0, (10, 1)),
+    ],
+)
+def test_compute_quota_split(
+    total: int, fraction: float, expected: tuple[int, int]
+) -> None:
+    """The budget is split as expected, clamping each path to >= 1 when capped."""
+    assert compute_quota_split(total, fraction) == expected
+
+
+@pytest.mark.unit
+def test_unlimited_gate_is_no_op() -> None:
+    """A capacity of 0 always grants acquisition."""
+    gate = ConcurrencyGate(0)
+    assert gate.capacity == 0
+    assert gate.acquire() is True
+    assert gate.acquire() is True
+    gate.release()  # must not raise
+
+
+@pytest.mark.unit
+def test_gate_blocks_when_exhausted() -> None:
+    """A capped gate rejects acquisition once full and recovers on release."""
+    gate = ConcurrencyGate(1)
+    assert gate.acquire() is True
+    assert gate.acquire() is False
+    gate.release()
+    assert gate.acquire() is True
+
+
+@pytest.mark.unit
+def test_gates_sized_from_settings(reset_gates: None) -> None:
+    """Cached gates pick up their capacity from settings."""
+    os.environ["MAX_QUEUED_GPU_REQUESTS"] = "4"
+    os.environ["SYNC_GPU_QUOTA_FRACTION"] = "0.5"
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+    assert get_sync_concurrency_gate().capacity == 2
+    assert get_async_concurrency_gate().capacity == 2
+
+
+@pytest.mark.unit
+def test_gates_unlimited_by_default(reset_gates: None) -> None:
+    """With the default cap of 0 both gates are unlimited."""
+    os.environ.pop("MAX_QUEUED_GPU_REQUESTS", None)
+    get_settings.cache_clear()
+    get_sync_concurrency_gate.cache_clear()
+    get_async_concurrency_gate.cache_clear()
+
+    assert get_sync_concurrency_gate().capacity == 0
+    assert get_async_concurrency_gate().capacity == 0

--- a/tests/unit/core/test_concurrency.py
+++ b/tests/unit/core/test_concurrency.py
@@ -44,14 +44,25 @@ def reset_gates() -> Generator[None, None, None]:
         (20, 0.25, (5, 15)),
         (1, 0.5, (1, 1)),
         (10, 0.0, (1, 9)),
-        (10, 1.0, (10, 1)),
+        (10, 1.0, (9, 1)),
+        (2, 0.5, (1, 1)),
     ],
 )
 def test_compute_quota_split(
     total: int, fraction: float, expected: tuple[int, int]
 ) -> None:
-    """The budget is split as expected, clamping each path to >= 1 when capped."""
+    """For total>=2 the split is exact and each path keeps >=1 slot."""
     assert compute_quota_split(total, fraction) == expected
+
+
+@pytest.mark.unit
+def test_compute_quota_split_never_exceeds_total_when_capped() -> None:
+    """For any total>=2, the two shares sum to exactly the configured total."""
+    for total in range(2, 33):
+        for fraction in (0.0, 0.25, 0.5, 0.75, 1.0):
+            sync, async_ = compute_quota_split(total, fraction)
+            assert sync >= 1 and async_ >= 1
+            assert sync + async_ == total
 
 
 @pytest.mark.unit

--- a/tests/unit/core/test_config.py
+++ b/tests/unit/core/test_config.py
@@ -6,8 +6,11 @@ from unittest.mock import patch
 import pytest
 
 from app.core.config import (
+    AuthSettings,
     DatabaseSettings,
     LoggingSettings,
+    RateLimitKeyStrategy,
+    RateLimitSettings,
     Settings,
     WhisperSettings,
     get_settings,
@@ -244,3 +247,109 @@ class TestGetSettings:
         """Test that get_settings returns a Settings instance."""
         settings = get_settings()
         assert isinstance(settings, Settings)
+
+
+class TestRateLimitSettings:
+    """Test RateLimitSettings class."""
+
+    def test_default_values_are_no_op(self) -> None:
+        """Rate limiting is disabled by default with sensible budgets."""
+        with patch.dict(os.environ, {}, clear=True):
+            settings = RateLimitSettings()
+            assert settings.ENABLED is False
+            assert settings.REQUESTS_PER_MINUTE == 60
+            assert settings.BURST == 10
+            assert settings.KEY_STRATEGY == RateLimitKeyStrategy.ip
+
+    def test_custom_values_via_env(self) -> None:
+        """Values are read from RATE_LIMIT__ prefixed environment variables."""
+        env = {
+            "RATE_LIMIT__ENABLED": "true",
+            "RATE_LIMIT__REQUESTS_PER_MINUTE": "5",
+            "RATE_LIMIT__BURST": "2",
+            "RATE_LIMIT__KEY_STRATEGY": "bearer_token",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = RateLimitSettings()
+            assert settings.ENABLED is True
+            assert settings.REQUESTS_PER_MINUTE == 5
+            assert settings.BURST == 2
+            assert settings.KEY_STRATEGY == RateLimitKeyStrategy.bearer_token
+
+    def test_rejects_non_positive_rpm(self) -> None:
+        """REQUESTS_PER_MINUTE must be >= 1."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        with patch.dict(
+            os.environ, {"RATE_LIMIT__REQUESTS_PER_MINUTE": "0"}, clear=True
+        ):
+            with pytest.raises(PydanticValidationError):
+                RateLimitSettings()
+
+
+class TestAuthSettings:
+    """Test AuthSettings class."""
+
+    def test_default_values_are_no_op(self) -> None:
+        """Authentication is disabled by default with no token."""
+        with patch.dict(os.environ, {}, clear=True):
+            settings = AuthSettings()
+            assert settings.ENABLED is False
+            assert settings.BEARER_TOKEN == ""
+
+    def test_custom_values_via_env(self) -> None:
+        """Values are read from AUTH__ prefixed environment variables."""
+        env = {"AUTH__ENABLED": "true", "AUTH__BEARER_TOKEN": "secret"}
+        with patch.dict(os.environ, env, clear=True):
+            settings = AuthSettings()
+            assert settings.ENABLED is True
+            assert settings.BEARER_TOKEN == "secret"
+
+    def test_enabled_requires_token(self) -> None:
+        """Enabling auth without a token raises a validation error."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        with patch.dict(os.environ, {"AUTH__ENABLED": "true"}, clear=True):
+            with pytest.raises(PydanticValidationError):
+                AuthSettings()
+
+
+class TestRequestShapingSettings:
+    """Test request-shaping fields on the top-level Settings."""
+
+    def test_defaults_are_no_op(self) -> None:
+        """Upload cap and queue cap default to unlimited."""
+        env = {"DEVICE": "cpu", "COMPUTE_TYPE": "int8"}
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings()
+            assert settings.MAX_UPLOAD_SIZE_MB == 0
+            assert settings.MAX_QUEUED_GPU_REQUESTS == 0
+            assert settings.SYNC_GPU_QUOTA_FRACTION == 0.5
+
+    def test_custom_values(self) -> None:
+        """Request-shaping fields are read from the environment."""
+        env = {
+            "DEVICE": "cpu",
+            "COMPUTE_TYPE": "int8",
+            "MAX_UPLOAD_SIZE_MB": "25",
+            "MAX_QUEUED_GPU_REQUESTS": "20",
+            "SYNC_GPU_QUOTA_FRACTION": "0.25",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            settings = Settings()
+            assert settings.MAX_UPLOAD_SIZE_MB == 25
+            assert settings.MAX_QUEUED_GPU_REQUESTS == 20
+            assert settings.SYNC_GPU_QUOTA_FRACTION == 0.25
+
+    def test_fraction_out_of_range_rejected(self) -> None:
+        """SYNC_GPU_QUOTA_FRACTION must be within [0, 1]."""
+        from pydantic import ValidationError as PydanticValidationError
+
+        env = {
+            "DEVICE": "cpu",
+            "COMPUTE_TYPE": "int8",
+            "SYNC_GPU_QUOTA_FRACTION": "1.5",
+        }
+        with patch.dict(os.environ, env, clear=True):
+            with pytest.raises(PydanticValidationError):
+                Settings()

--- a/tests/unit/core/test_rate_limit.py
+++ b/tests/unit/core/test_rate_limit.py
@@ -1,0 +1,110 @@
+"""Unit tests for the slowapi-backed rate-limit helpers."""
+
+import os
+from collections.abc import Generator
+
+import pytest
+from starlette.requests import Request
+
+from app.core.config import get_settings
+from app.core.rate_limit import (
+    rate_limit_key,
+    rate_limit_value,
+    rate_limiting_disabled,
+    reset_rate_limiter,
+)
+
+_RL_ENV_KEYS = (
+    "RATE_LIMIT__ENABLED",
+    "RATE_LIMIT__REQUESTS_PER_MINUTE",
+    "RATE_LIMIT__BURST",
+    "RATE_LIMIT__KEY_STRATEGY",
+)
+
+
+@pytest.fixture
+def reset_rate_limit_env() -> Generator[None, None, None]:
+    """Snapshot and restore RATE_LIMIT__ env vars around each test."""
+    saved = {key: os.environ.get(key) for key in _RL_ENV_KEYS}
+    get_settings.cache_clear()
+    yield
+    for key, value in saved.items():
+        if value is None:
+            os.environ.pop(key, None)
+        else:
+            os.environ[key] = value
+    get_settings.cache_clear()
+
+
+def _make_request(headers: dict[str, str] | None = None, client_ip: str = "1.2.3.4"):
+    """Build a minimal Starlette Request for key-function tests."""
+    raw_headers = [(k.lower().encode(), v.encode()) for k, v in (headers or {}).items()]
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/v1/audio/transcriptions",
+        "headers": raw_headers,
+        "client": (client_ip, 12345),
+    }
+    return Request(scope)
+
+
+@pytest.mark.unit
+def test_key_uses_client_ip_by_default(reset_rate_limit_env: None) -> None:
+    """The default ip strategy buckets by the client address."""
+    os.environ["RATE_LIMIT__KEY_STRATEGY"] = "ip"
+    get_settings.cache_clear()
+
+    key = rate_limit_key(_make_request(client_ip="9.9.9.9"))
+
+    assert key == "9.9.9.9"
+
+
+@pytest.mark.unit
+def test_key_uses_bearer_token_when_configured(reset_rate_limit_env: None) -> None:
+    """The bearer_token strategy buckets by the presented token."""
+    os.environ["RATE_LIMIT__KEY_STRATEGY"] = "bearer_token"
+    get_settings.cache_clear()
+
+    key = rate_limit_key(_make_request(headers={"Authorization": "Bearer abc123"}))
+
+    assert key == "token:abc123"
+
+
+@pytest.mark.unit
+def test_bearer_strategy_falls_back_to_ip(reset_rate_limit_env: None) -> None:
+    """Without a usable token, bearer_token strategy falls back to client IP."""
+    os.environ["RATE_LIMIT__KEY_STRATEGY"] = "bearer_token"
+    get_settings.cache_clear()
+
+    key = rate_limit_key(_make_request(client_ip="5.5.5.5"))
+
+    assert key == "5.5.5.5"
+
+
+@pytest.mark.unit
+def test_rate_limit_value_reflects_settings(reset_rate_limit_env: None) -> None:
+    """The limit string combines the per-minute and burst budgets."""
+    os.environ["RATE_LIMIT__REQUESTS_PER_MINUTE"] = "30"
+    os.environ["RATE_LIMIT__BURST"] = "3"
+    get_settings.cache_clear()
+
+    assert rate_limit_value() == "30/minute;3/second"
+
+
+@pytest.mark.unit
+def test_rate_limiting_disabled_reflects_settings(reset_rate_limit_env: None) -> None:
+    """The exemption predicate tracks the ENABLED flag."""
+    os.environ.pop("RATE_LIMIT__ENABLED", None)
+    get_settings.cache_clear()
+    assert rate_limiting_disabled() is True
+
+    os.environ["RATE_LIMIT__ENABLED"] = "true"
+    get_settings.cache_clear()
+    assert rate_limiting_disabled() is False
+
+
+@pytest.mark.unit
+def test_reset_rate_limiter_is_callable() -> None:
+    """The reset helper clears in-memory storage without raising."""
+    reset_rate_limiter()

--- a/uv.lock
+++ b/uv.lock
@@ -1060,6 +1060,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2067,6 +2079,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b8/39/6fc58ca81492db047149b4b8fd385aa1bfb8c28cd7cacb0c7eb0c44d842f/lightning_utilities-0.15.2.tar.gz", hash = "sha256:cdf12f530214a63dacefd713f180d1ecf5d165338101617b4742e8f22c032e24", size = 31090, upload-time = "2025-08-06T13:57:39.242Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/73/3d757cb3fc16f0f9794dd289bcd0c4a031d9cf54d8137d6b984b2d02edf3/lightning_utilities-0.15.2-py3-none-any.whl", hash = "sha256:ad3ab1703775044bbf880dbf7ddaaac899396c96315f3aa1779cec9d618a9841", size = 29431, upload-time = "2025-08-06T13:57:38.046Z" },
+]
+
+[[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
 ]
 
 [[package]]
@@ -4652,6 +4678,18 @@ wheels = [
 ]
 
 [[package]]
+name = "slowapi"
+version = "0.1.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a0/99/adfc7f94ca024736f061257d39118e1542bade7a52e86415a4c4ae92d8ff/slowapi-0.1.9.tar.gz", hash = "sha256:639192d0f1ca01b1c6d95bf6c71d794c3a9ee189855337b4821f7f457dddad77", size = 14028, upload-time = "2024-02-05T12:11:52.13Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/bb/f71c4b7d7e7eb3fc1e8c0458a8979b912f40b58002b9fbf37729b8cb464b/slowapi-0.1.9-py3-none-any.whl", hash = "sha256:cfad116cfb84ad9d763ee155c1e5c5cbf00b0d47399a769b227865f5df576e36", size = 14670, upload-time = "2024-02-05T12:11:50.898Z" },
+]
+
+[[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -5375,6 +5413,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "setuptools" },
+    { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "torch", version = "2.8.0", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "python_full_version < '3.14' and sys_platform == 'darwin'" },
     { name = "torch", version = "2.8.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(python_full_version >= '3.14' and sys_platform == 'darwin') or (platform_machine != 'x86_64' and sys_platform != 'darwin')" },
@@ -5437,6 +5476,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.33.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = "==0.15.12" },
     { name = "setuptools", specifier = ">=78.1.1" },
+    { name = "slowapi", specifier = ">=0.1.9" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.0" },
     { name = "torch", marker = "sys_platform == 'darwin'", specifier = "<=2.8.0", index = "https://download.pytorch.org/whl/cpu" },
     { name = "torch", marker = "platform_machine != 'x86_64' and sys_platform != 'darwin'", specifier = "<=2.8.0", index = "https://download.pytorch.org/whl/cpu" },
@@ -5453,6 +5493,92 @@ requires-dist = [
     { name = "whisperx", specifier = "==3.8.5" },
 ]
 provides-extras = ["postgres", "dev"]
+
+[[package]]
+name = "wrapt"
+version = "2.2.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/9f/06263fcd8ad6c405f05a3905fd7a84dd3176eb5ad46e44bccc0cd16348bb/wrapt-2.2.1.tar.gz", hash = "sha256:6744f504375775d7609c82c8d3d94af1c9a6f05586984536905908ba905277b9", size = 127620, upload-time = "2026-05-22T14:49:43.056Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/8b/84bc1ea68b620fe0e2696a8cff07e82f4b962d952ab14efee8955997bb70/wrapt-2.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f68f478004475d97906686e702ddbddeaf717c0b68ad2794384308f2dc713ae", size = 80093, upload-time = "2026-05-22T14:47:27.074Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/8f/64ec81194a0bc708d9720174c998c8a32116e82b5b32c04e20a7fe01176c/wrapt-2.2.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e422b2d647a65d6b080cad5accd09055d3809bdff00c76fba8dca00ca935572a", size = 81183, upload-time = "2026-05-22T14:47:29.062Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/3d186944aae923631d1def58f4c4ff8f0b6309906afc0b6978de3e69b3e0/wrapt-2.2.1-cp310-cp310-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:036dfb40128819a751c6f451c6b9c10172c49e4c401aebcdb8ecf2aec1683598", size = 152494, upload-time = "2026-05-22T14:47:30.583Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d1/6b3d0ea995b867d2862aad5619bd5e17de09a9d64a821f46832dcd272d40/wrapt-2.2.1-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:09ac16c081bebfd15d8e4dfa5bdc805990bbd52249ecff22530da7a129d6120b", size = 154310, upload-time = "2026-05-22T14:47:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/4b/37ecb90a8c3753e580327fb40731a984b754e3df65d2ef932bf359fe4adc/wrapt-2.2.1-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:07be671fa8875971222b0ba9059ed8b4dc738631122feba17c93aa36b4213e9a", size = 149002, upload-time = "2026-05-22T14:47:34.021Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/d0/918884d9dfa84d0d135b42a51c00910f5c5447fe7a5e211a8e16ac324dd4/wrapt-2.2.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:93fc2bf40cd7f4a0256010dce073d44eeb4a351b9bca94d0477ce2b6e62532b3", size = 153185, upload-time = "2026-05-22T14:47:35.722Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/00/382299d8ced610b29b59b099a89eda821e8c489aa152b7183748ac83f32a/wrapt-2.2.1-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:ba519b2d765df9871a25879e6f7fa78948ea59a2a31f9c1a257e34b651994afc", size = 148040, upload-time = "2026-05-22T14:47:37.052Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/46/62a79b79e35bbebb1207ca5d15b81192f37f20cc5659cf4e3ce955b7fcc8/wrapt-2.2.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:9011395be8db1827d106c6449b4bb6dd17e331ff6ec521f227e4588f1c78e46f", size = 151773, upload-time = "2026-05-22T14:47:38.713Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/db/95c152151d206d4b430516c89725306e92484072f38e65492afde63f6d19/wrapt-2.2.1-cp310-cp310-win32.whl", hash = "sha256:a8f7176b83664af44567e9cc06e0d3827823fcc1a5e52307ebb8ac3aa95860b9", size = 77393, upload-time = "2026-05-22T14:47:40.061Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d3/882d50452c6fbd13f24fe5d2644b97cdad2565a7e1522cbb6312de8a52cf/wrapt-2.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:d7f513d3185e6fec82d0c3518f2e6365d8b4e49f5f45f29640d5162d56a23b54", size = 80350, upload-time = "2026-05-22T14:47:41.194Z" },
+    { url = "https://files.pythonhosted.org/packages/58/0f/148376523b4e370692286a9ba14d5715cf3c5b86da3bd3630926367b6b73/wrapt-2.2.1-cp310-cp310-win_arm64.whl", hash = "sha256:44255c84bc57554fed822e83e70036b51afa9edb56fc7ca56c54410ece7898c9", size = 79149, upload-time = "2026-05-22T14:47:42.835Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/ac/4370bde262c0e633e6c4f0e56d55095710024cf9a5cecc20c59a10de483c/wrapt-2.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dd57607acc85678925940bd5df0385ff8332083a32fa8d7a43f8767f4997263c", size = 80321, upload-time = "2026-05-22T14:47:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/79/b8ff3a61e71babf58a8cf4c0d63358e8bad383e15bf7f35e62d2f6b6e4a4/wrapt-2.2.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:1ae574d65c9fa8e86f64f6a7c2668f9fcd507b183e0e577619f504b883cb0a6c", size = 81216, upload-time = "2026-05-22T14:47:45.243Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/fd/c0cac1f77c9c4f6fe58a920ca632ce379bb8be928720e11e8d73de28a5e9/wrapt-2.2.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9a04c28c10ba7fd12842b109d2edb0678872a2fe65277ca4ff06a0d61edee245", size = 159208, upload-time = "2026-05-22T14:47:47.176Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/4f/744132a7b2fbefa6b81118ec5942eca5fc2e9a129f9055a0c5e46885a549/wrapt-2.2.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3e2f02472a1cbbf3884b365714a810b5947134a95ad6952b554cb8cce9d492b0", size = 160322, upload-time = "2026-05-22T14:47:49.04Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/95/b7cd9a22a06cf93e6482904ee6afc956248983553593fd1009296d1b3b31/wrapt-2.2.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ac2745950b2bff80219c15ebf2fa9d8427eba7e249739f97e55c9d169e47e9e1", size = 153243, upload-time = "2026-05-22T14:47:50.386Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4a/eb79423192015f46f0db2872e7e04a3dde8d359b83411e8959e7c9287eaa/wrapt-2.2.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:67a97e5b6c457f0cd3cfc19ebb2d84463e60c3ece754cc831e4281a3ca29bb18", size = 159231, upload-time = "2026-05-22T14:47:51.753Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/dc/435015b58ce33c6fc4104158fa91ddb0e809ab03a5751fb7465d1d461456/wrapt-2.2.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:c803a3d331796255af51ba2c79ed0ac8275865b516c09e61f248d1e7aff31ce9", size = 152351, upload-time = "2026-05-22T14:47:53.214Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ac/5d203f98df8fd136b95c5227139aea02d34505e18baf812d0c005df61963/wrapt-2.2.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:9b984d1eb252145d6302c1dbd5e87fc6d404d45531447c84eadec04bf1fcb027", size = 158347, upload-time = "2026-05-22T14:47:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/52/2f/a92427dbdc74e54c1674abbed27e61b2cb5e7a94441b8c1270c70671d928/wrapt-2.2.1-cp311-cp311-win32.whl", hash = "sha256:8a983a603a18c8708f024f7f6991b2e66159219abbf894634c5056243c55f3cd", size = 77562, upload-time = "2026-05-22T14:47:56.275Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/56/987b9c13b3e1c1a3c6de71284076f996b79caec90e75a87c044a40c23db9/wrapt-2.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:9c210a6994b21aa9b29e81c8d11560e8fdab54c117e9cff37870d0a27bde1343", size = 80616, upload-time = "2026-05-22T14:47:57.854Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/25/d01f560888d99d94a959c85533de349ce68d71ace3f2591d6ea8f632cfed/wrapt-2.2.1-cp311-cp311-win_arm64.whl", hash = "sha256:401229e9d63ca09f9b8891ecf83798d26c11bbb445d11ed9f1836b6d4585b38a", size = 79025, upload-time = "2026-05-22T14:47:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/89/0c/bfae7b9401583b6d05938cd16dedc43857d96da2f8a3d50d78cc515bf6ff/wrapt-2.2.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:3ffad790d9d11d8ecf9f17c4bb671a5b4089e4d8b575c46c5129597f41f836b0", size = 81021, upload-time = "2026-05-22T14:48:00.313Z" },
+    { url = "https://files.pythonhosted.org/packages/26/58/80f6a6599f933f4caecc1cb3ee88a04faf81e8b9bddbd6109c688dd63e0f/wrapt-2.2.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:628f5220c7a904d5fc78f7075c8d7871433eb6d035c94728a22fdf85f193d2a8", size = 81692, upload-time = "2026-05-22T14:48:01.49Z" },
+    { url = "https://files.pythonhosted.org/packages/17/93/fb357cc7847c58a8ae790be718903afa81a28d23e642c843dc4129e8a0b2/wrapt-2.2.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:61acce4257a9883669703c525447c5b4c392edf0f987ae77ec32668440158f0e", size = 169364, upload-time = "2026-05-22T14:48:02.791Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/0b/76b601ee309a8bd556af0eecb184394c20b3c49aa9c8e085aa1ffacc2568/wrapt-2.2.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:727ab4244622cd6ad2390f322642090c877d2e83a608d2653a7643ae5368d926", size = 171079, upload-time = "2026-05-22T14:48:04.22Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/87/ee3f32d5658e3e26d3e0e457922b47a36dd3bfbdfee7f97bb3e802344a66/wrapt-2.2.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:03df9ebed4c73ab93fa8c07e3d41d818dfca1852b15731a3de59457b27814624", size = 160205, upload-time = "2026-05-22T14:48:05.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d0/ae2fd64277a67f5d7bffcf2d05eea1e476263fb2a072baf0b0129ab85984/wrapt-2.2.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0d9ff006f420b2ec8296aa56ade43ea7da3e997e85769f0aafc5e0661aacb710", size = 168922, upload-time = "2026-05-22T14:48:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f3/2d541a060c5bbafb9400bca4917e4d78bfd1f239f404782c86831a8f6b29/wrapt-2.2.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:844c858fc3bb7eacc0ba8efa904935d16aac6a4470948ad1e7e55c9f5a2a665f", size = 158388, upload-time = "2026-05-22T14:48:08.629Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/68/8d92c8800c57e93cb116ae9e9d6cbafc34fade5ee9f9107b6f203fb4dc35/wrapt-2.2.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:87bacdaf225117a342a20d9c03438d701c02112f6e3f351ce9b7f32354f14797", size = 167682, upload-time = "2026-05-22T14:48:10.042Z" },
+    { url = "https://files.pythonhosted.org/packages/30/72/83ea3790ea352439442349388e29ff07b76e0686265f9088bbb505d1608d/wrapt-2.2.1-cp312-cp312-win32.whl", hash = "sha256:2f8c90c8afde51969487be4e1343ae049b268854877d415c2510baf833775052", size = 77857, upload-time = "2026-05-22T14:48:11.782Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/cb/99450668dd3502d62a54a1c8aa56e44f34cb8c1261b381cfe2e7926c3b75/wrapt-2.2.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ce32763ac31ce94fe9aada947e479b1975012bff166da409b4b9e4e376cf7e5", size = 80825, upload-time = "2026-05-22T14:48:13.046Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/3a/87512881be64e743f9ee4c66f4cbe8e884974bef2a5989af71f999653ac7/wrapt-2.2.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d1b4d0e0c2119587a31f5c029abd547e0c81d93b89d394566fe1588659eb579", size = 79087, upload-time = "2026-05-22T14:48:14.323Z" },
+    { url = "https://files.pythonhosted.org/packages/88/d1/a1b08f8f4fac8cbb156fa51cf64ee2c7f7f74f9875ba3cf70b3c58368694/wrapt-2.2.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d2beb1c7cab10603aecdc42f8edd6ff013f9a32e4543474e38e6b77ce9975aeb", size = 80831, upload-time = "2026-05-22T14:48:15.598Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ce/57890814991446a845e09b3445ce8b694f27eb0577004f2c2a36a9772ed4/wrapt-2.2.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e0cb7e4dd71f4c32e5e84843cd3c4cd65dda034314004bbe1d7f99af2426ab80", size = 81375, upload-time = "2026-05-22T14:48:17.071Z" },
+    { url = "https://files.pythonhosted.org/packages/38/65/08d7a6c76ac4493bdb668205ee9c1de1bd5daca61717c3e9aa49b4c01499/wrapt-2.2.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95821352042722cd9f1108874579a47989d0a7e12a37d87d2fc4af20fd99ab8a", size = 167417, upload-time = "2026-05-22T14:48:18.303Z" },
+    { url = "https://files.pythonhosted.org/packages/62/ce/f1ccbee7a1bfe5cdc6b3da6bab4b45713d628b9294da32a39f563d648140/wrapt-2.2.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:abd621552ede77c4c69be7fac44ba911225b0c812b6ba604e5964cf98085b474", size = 166948, upload-time = "2026-05-22T14:48:19.768Z" },
+    { url = "https://files.pythonhosted.org/packages/86/2a/f85d48d1cd4869aee6704028d257d740a47c1c467b457ce396b4b5b55d07/wrapt-2.2.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e3677c7146ce694874941ba82b57092cc4875445aadf29d72807351023105143", size = 158148, upload-time = "2026-05-22T14:48:21.96Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/5c/93939ad11d4a12358ab1aab219a2ef5efa5612e0db6b9fc65af8af1a891b/wrapt-2.2.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9a5934eaea872e17936b5f45501eba5ab0bce9a74122e172b663d7c28c459c4a", size = 165905, upload-time = "2026-05-22T14:48:23.373Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/22/b8c2aa89862ff58605934d7abf4b70e6a5a1c33df96656f49035ccdf1c8a/wrapt-2.2.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f5b9daf6b629fce418e0cc3dd0436eac045188fa35deadb7a7f3941d5b8203f9", size = 156712, upload-time = "2026-05-22T14:48:24.767Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/bf00a7b02239c12bb02ddcc3c0b971bfcc36e578c5a44f1ccfef5b458545/wrapt-2.2.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f53ac9f3ef573326d009ed809beff4efcac6451931c2b8132586da4b9e53ff31", size = 166560, upload-time = "2026-05-22T14:48:26.83Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/93/6390ca9c5b787683cef588d04f57c8d41b9a2323b5597a65f18638c90ef2/wrapt-2.2.1-cp313-cp313-win32.whl", hash = "sha256:1ffa9cfd4bdb581539951b14ae661ff20ed0c3599b3e911a131ee0ec5ac11337", size = 77817, upload-time = "2026-05-22T14:48:28.221Z" },
+    { url = "https://files.pythonhosted.org/packages/97/73/ce10f0e71c0cfaa1a65faadb8efd4852028b3bb9ba28932b8889df769d38/wrapt-2.2.1-cp313-cp313-win_amd64.whl", hash = "sha256:368eac1e20fd0bb03dd3cc42bf9887154c3861b60989389ccb5fac032617d215", size = 80736, upload-time = "2026-05-22T14:48:30.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/4c/89f4a6818fafbbd840330e4fa3873073e1bfc166133a64cac7f8fde7a5e3/wrapt-2.2.1-cp313-cp313-win_arm64.whl", hash = "sha256:c754dafdf5aaf0b401b644a90a30046929a0dd1a536e0ff0ec959a59155d9c7f", size = 79099, upload-time = "2026-05-22T14:48:31.405Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/f2/9a8741c46f8c208ac0a45b25ba170bcb4fb72a2781d5fb97dbd7b6be73cb/wrapt-2.2.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:ed928d0fda15fc0adc8d13305c8b3c0f2fba5b0669950c9e6d019d9162a3b3e8", size = 82802, upload-time = "2026-05-22T14:48:33.307Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0d/e9c855716a3705eef1416456bdf062b60620726fdc59428ff670fc3c60dc/wrapt-2.2.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fafb4e739e43544d12cb4abd1605fd4683b6ca6a9ad682b7fd8f4d21973eafa8", size = 83329, upload-time = "2026-05-22T14:48:34.593Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/d6/a88f1c13112b7831adac75cea65d8310e0d696d570c8961844c90a57b865/wrapt-2.2.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:74d6a0c31472fe5d814917266b9f46495d7c61ed890af08b468acea92fb89a8d", size = 202937, upload-time = "2026-05-22T14:48:35.859Z" },
+    { url = "https://files.pythonhosted.org/packages/42/65/e29d54aef06a4d898a5b8a25589a0b3769bde454f922fad8f6f89fbfb650/wrapt-2.2.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab5be648d5a0b86b7438864f8df3c705a65cef35a2fd3e5561e3e203167e0f27", size = 209997, upload-time = "2026-05-22T14:48:38.153Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/91/e4454263516cf0e12640912fbca9a83654e424f0a6ddb79f5cd7ce14bf33/wrapt-2.2.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d8f204c8e3a8bf9ece17e0a83d137fd807440977f8a5e762d59306795011440", size = 194856, upload-time = "2026-05-22T14:48:39.69Z" },
+    { url = "https://files.pythonhosted.org/packages/de/d0/fe0ee202286afdf4a7f77dd29f195703145764d572aec209c5086e57d924/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d047f6498c973874ba08ac3f97c69a2c4b2211c8de6f4c205f75cb1c9522596e", size = 205654, upload-time = "2026-05-22T14:48:43.456Z" },
+    { url = "https://files.pythonhosted.org/packages/23/b6/87d860dfc6460c246af70b1fd5c8b76df77571b42a493459423ded94fd7d/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:7a4fdb9326aab4a5a477a1640e5ad786a8495901009d7e7b038371edd23a9d2b", size = 192206, upload-time = "2026-05-22T14:48:44.858Z" },
+    { url = "https://files.pythonhosted.org/packages/df/46/3eea8cde077d985f239a38c0257087b8064fd9ee9b1a99e282d2c86da4ef/wrapt-2.2.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:c8cc5094b08abeae52da9c73c8a32003623be691a5193df2f4e3eac3d557c394", size = 198428, upload-time = "2026-05-22T14:48:46.319Z" },
+    { url = "https://files.pythonhosted.org/packages/18/dc/b927ee9c7fc67adc3a5658f246a0d275425eb840ba36e7b702e70f18bde8/wrapt-2.2.1-cp313-cp313t-win32.whl", hash = "sha256:9907a4402ab6db12b7077a0ea5d7a4d028ecb22c8eee2b53527080d347cd1562", size = 79448, upload-time = "2026-05-22T14:48:47.901Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/b3/fd30b473fe498c70e6b9a5f328b8d3fbaf1b8c3c481465f59724bba8eb70/wrapt-2.2.1-cp313-cp313t-win_amd64.whl", hash = "sha256:5590d63f5243251641cf543009b4c9314a79d0598fdb8a8e4cfc918494536c53", size = 83021, upload-time = "2026-05-22T14:48:49.201Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/f3/96c39153a8737a6e9aa85adef254ac4195bea3f2d24efc60472ccc3c9e2e/wrapt-2.2.1-cp313-cp313t-win_arm64.whl", hash = "sha256:c318a64b53d97b841d7b5e637517e50a27be64bc695128422953d4b21710954e", size = 80295, upload-time = "2026-05-22T14:48:50.479Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/a3/11d7f34ebbf3231bc907a3e6d5ee051b14d034c1bc7b65a97d5cc00516df/wrapt-2.2.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f56a647e4eaf5f0ca40330fb070f566bdf9f7b0db89a1af20d71c28dcd7a0ab", size = 80879, upload-time = "2026-05-22T14:48:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3c/b74cfd984cef560b900fb1a727af20352d89e1f06bf2e1114dd3f00f5f5a/wrapt-2.2.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:64b7deeda4b70408e382328d8bbe52a256fe9bc63ae3db86d804608367e5422c", size = 81462, upload-time = "2026-05-22T14:48:53.18Z" },
+    { url = "https://files.pythonhosted.org/packages/15/a3/7c8f704b8dc07dfe0a5d01c2edbfd88317aa8e5e3fa7c743eb7a085ae767/wrapt-2.2.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b9cf53ba90717db2e292401de290776c498d4bbfb0d4a559ca2895db8b9dcb5c", size = 167251, upload-time = "2026-05-22T14:48:54.562Z" },
+    { url = "https://files.pythonhosted.org/packages/80/85/a34d1888d97247da6c2ff6118c3a721c73ed8cc4dd198c00208bb73b6f80/wrapt-2.2.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cf3638274ab9d9b724c9baa0b4c04e132cd6faefb78b4dd3dd1a02a4bdaad41e", size = 166316, upload-time = "2026-05-22T14:48:56.065Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d7/72ffaeb01eebc704afe3fb99e840480f4bda45f0fa66e3381b6a39251c8f/wrapt-2.2.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:aed9658797d0b45d6c49adcfc6b41f66e6f2d0c6de3ec79e16cf4b1855df240f", size = 157952, upload-time = "2026-05-22T14:48:57.924Z" },
+    { url = "https://files.pythonhosted.org/packages/24/5b/36f5d6b024e4edfdd90b140742d11ebcf7836daf5c9daf326c55c24db412/wrapt-2.2.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:1d676ee388bc42a04d56dd7deb5605244dac2e35cc2fadbb43c9fa25bbd93508", size = 166130, upload-time = "2026-05-22T14:48:59.384Z" },
+    { url = "https://files.pythonhosted.org/packages/81/06/9296d9e97bfdef5483dfcc859d57b095b257144b2bc5300ab521e06f4bc7/wrapt-2.2.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e395f7bc31851ef9b612050368cb446e9bc14cd7454b025018980349caf25ae5", size = 156604, upload-time = "2026-05-22T14:49:00.921Z" },
+    { url = "https://files.pythonhosted.org/packages/53/37/16953929ed6776175720e58fc966e779926d8d71e2c7b2273230590ca71f/wrapt-2.2.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5f1845c2a8cc1180ccccfa45785dd06f562730d19ef75be180334254012b6283", size = 166007, upload-time = "2026-05-22T14:49:02.332Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/73/20ee58c0612dae7c31131a7095345812ed2c7b389019e175f68cde34e5b4/wrapt-2.2.1-cp314-cp314-win32.whl", hash = "sha256:436addbc4bb4fc0a88c702577f51195d7d73683a7f3e0e5b253d8404d7847243", size = 78327, upload-time = "2026-05-22T14:49:03.722Z" },
+    { url = "https://files.pythonhosted.org/packages/22/b3/ef7c3295d02e0448a71c639a36a057f46d524d057c9486291a7a3039e65c/wrapt-2.2.1-cp314-cp314-win_amd64.whl", hash = "sha256:50972a1d974ea07725a7f6b1cec5f8759008afd030a0024843ebe7d52de47f2b", size = 81144, upload-time = "2026-05-22T14:49:05.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/dc/7bdf336953f99f4ceb0a584bb8870e42c8f26f93ea10c87834dad62f1668/wrapt-2.2.1-cp314-cp314-win_arm64.whl", hash = "sha256:1c9934ea5d92957e3cd0adbc0845539dccfd62710ebe16195a8c66c53954db36", size = 79569, upload-time = "2026-05-22T14:49:06.413Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/6d/6dfae80150ff1919c356d1dd528f049bcdfaae29b4d284bc957e022caef4/wrapt-2.2.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:17de18fc12cea55b8a9587314cb830573e37fb33b247a7515696350863714188", size = 82892, upload-time = "2026-05-22T14:49:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/82/7b/4e34766a7d7804ffce9e71befe47e9b3225dc350c49c94493c4ab39fd3a5/wrapt-2.2.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a9dec1aca52dddde7df94818310fa2fe79739c8f385b2014c4cb1035f5508199", size = 83333, upload-time = "2026-05-22T14:49:09.257Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/57/0b34db3e8de44ccfece62d7b337abd1631dd810f5adc5f3db571727836b5/wrapt-2.2.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:69f2e9244542cb34dd59c7f073445b9e54ad9f3fce8d93606c368a1b499fc413", size = 202899, upload-time = "2026-05-22T14:49:10.572Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/45/ac0c459f154b99d92789a6cba7ca727185b83513b986f8ec7fe2aacddcbf/wrapt-2.2.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2d83966dc7f4f45e8b97b5933685ac2e6e67fc0e19246ea314bceb9a8970c956", size = 209986, upload-time = "2026-05-22T14:49:12.229Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/77e37ff33ad018fa81ade52c25fa327b80b56f81d734279a63614fcb4cbc/wrapt-2.2.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:78b0aa6bfb7be8deed0ab23e7aa028cc5210c29bc2d32a04d52b50e517a7307e", size = 194893, upload-time = "2026-05-22T14:49:14.139Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/9d/7ea651d1ab032fc5fa222fbec91d0f8a1397f6ae04ebb93fa7219aa921d7/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:05d5cb74d1b232ec8cfa130a8f900708699ff2491d97b8f85a4cdc5996294b85", size = 205636, upload-time = "2026-05-22T14:49:15.714Z" },
+    { url = "https://files.pythonhosted.org/packages/09/af/8e88031a701275b9085c54e64bc88c0b1cd55c77eadd400691c371cd76c4/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f6518b94edb9150452e9aba08027d4cc293433753ec1fbefb4629a21cbc74181", size = 192267, upload-time = "2026-05-22T14:49:17.283Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/a8/e657ca876b06710194f243d81c4b0896ade646e244bdbec2d87c8c56a8bd/wrapt-2.2.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ed55af48b3eb28f43228ca2306788892bcb629eb2b5c4876e2a3659872c2f17a", size = 198378, upload-time = "2026-05-22T14:49:18.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/59/822efe4ea722a3961331bfa35b7d90937790d2c20f0616de1997ccc3aebd/wrapt-2.2.1-cp314-cp314t-win32.whl", hash = "sha256:2e08688ab16525897da6589d56d0aebaf417bbe91c2d8e3b96203b1efa596e85", size = 80226, upload-time = "2026-05-22T14:49:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/31/2a7dc5f6abb2fca0b6e1610e120419f603650aceb4f1d3ac4cae0354e162/wrapt-2.2.1-cp314-cp314t-win_amd64.whl", hash = "sha256:fd0135d34387f5fd087d9be368ea77ea89cf2451dc1cd1c622d35021bcb3ab50", size = 83835, upload-time = "2026-05-22T14:49:21.634Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/c0/782b86e28d1ceebeb74cccea12d2cd3d2ba0bd68e3dec20b1bc5873f6127/wrapt-2.2.1-cp314-cp314t-win_arm64.whl", hash = "sha256:f70db64e8266d7c45d3b735f2e08eeb434b5e03da9a479ae42b2e2e486a21a00", size = 80722, upload-time = "2026-05-22T14:49:23.59Z" },
+    { url = "https://files.pythonhosted.org/packages/53/46/29ac9daf11a86c22a8c38cd9236c62928ccae83f7ceb06bd3b0467cf9d05/wrapt-2.2.1-py3-none-any.whl", hash = "sha256:3aafea2975caef8ca49400640dde02cc7426e798f24870ed01f490bc3cffd32f", size = 61000, upload-time = "2026-05-22T14:49:41.593Z" },
+]
 
 [[package]]
 name = "wsproto"


### PR DESCRIPTION
## Summary

Implements #533 — adds optional, configurable protection across **all** transcription endpoints (`/speech-to-text`, `/service/*`, `/v1/audio/*`). **Every feature is a no-op by default**, so existing deployments are unaffected until they opt in. All knobs read `get_settings()` per request, so they toggle at runtime.

- **Upload size cap** (`MAX_UPLOAD_SIZE_MB`) → HTTP 413 via `MaxUploadSizeMiddleware`, enforced from `Content-Length` before the body is read.
- **Per-caller rate limiting** (`RATE_LIMIT__*`, slowapi) → HTTP 429 + `Retry-After`, keyed by client IP or bearer token.
- **Route-level concurrency caps** (`MAX_QUEUED_GPU_REQUESTS`, `SYNC_GPU_QUOTA_FRACTION`) → HTTP 503 + `Retry-After`, splitting a budget between the sync (`/v1/audio/*`) and async background paths so neither starves the other.
- **Optional shared bearer-token auth** (`AUTH__*`) applied API-wide (health endpoints excluded) → HTTP 401.

New modules: `app/api/middleware.py`, `app/api/security.py`, `app/core/rate_limit.py`, `app/core/concurrency.py`. Adds `slowapi` dependency, exception handlers (401/429/503 with OpenAI-style envelopes), and regenerates `openapi.json`/`yaml`. Documented in README, CLAUDE.md, and `.env.example`.

> Note: rate-limit and concurrency state are kept in-process, so — like the existing GPU semaphore — these limits assume a single worker process. Multi-worker support is tracked separately per the issue's out-of-scope section.

## Test plan

- [x] Unit tests for config, rate-limit helpers, concurrency gates, auth/concurrency deps, and the upload middleware
- [x] E2E `tests/e2e/test_api_protection.py`: 413 / 429 (+Retry-After) / 503 (+Retry-After) / 401 on one sync and one async endpoint, plus no-op-by-default
- [x] `ruff check`, `ruff format --check`, `mypy app/` clean
- [x] Fast suite green (436 passed); new modules ~100% covered, total 83% without slow tests
- [ ] Full suite incl. slow ML e2e (verified in CI — model download unavailable locally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional API protection: upload-size enforcement (HTTP 413), per-caller rate limiting (HTTP 429 + Retry-After), GPU request concurrency caps (HTTP 503 + Retry-After), and optional bearer‑token auth (HTTP 401).

* **Documentation**
  * Expanded README/CLAUDE/.env example and OpenAPI docs to describe configuration, behaviors, and example env settings.

* **Tests**
  * Added unit and e2e tests covering upload limits, rate limiting, concurrency gates, auth, and new error responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pavelzbornik/whisperX-FastAPI/pull/536?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->