### PR TITLE
ci: enforce conventional PR titles and bump release-please to v5 (node24)

### DIFF
--- a/.github/workflows/pr-title-lint.yml
+++ b/.github/workflows/pr-title-lint.yml
@@ -1,0 +1,19 @@
+name: PR Title Lint
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+permissions:
+  contents: read
+jobs:
+  conventional-title:
+    name: Validate Conventional Commit title
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071
+        uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7
         id: release
         with:
           token: ${{ secrets.PAT_TOKEN }}


### PR DESCRIPTION
## Why

release-please silently skipped the `0.7.0` release because the merge commits on `main` (`Add OpenAI-compatible … (#531)`, `Dev (#535)`) were **not valid Conventional Commits**, so it counted 0 releasable commits. This PR addresses the root cause and a related deprecation.

## Changes

1. **New `PR Title Lint` workflow** (`amannn/action-semantic-pull-request` @ v6.1.1) — validates that every PR title is a Conventional Commit. Combined with squash-merging using the PR title, this prevents non-conventional subjects (`Dev`, `Add …`) from reaching `main` and being ignored by release-please.
2. **Bump `googleapis/release-please-action` v4 → v5.0.0** — v5's only breaking change is the upgrade to **Node 24**, resolving the Node 20 deprecation warning (forced June 16, 2026). It also bumps the bundled release-please core 17.3.0 → 17.6.0.

Both actions are pinned by commit SHA, matching the repo convention.

## Follow-up (not in this PR)

To fully close the loop, set the repo's **squash-merge default to use the PR title** so the linted title becomes the commit subject on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)