### PR TITLE
fix(tasks): record retry_count when a retried task completes

### DIFF
--- a/app/services/audio_processing_service.py
+++ b/app/services/audio_processing_service.py
@@ -263,6 +263,11 @@ def process_audio_task(
                         "end_time": end_time,
                         # Clear any error recorded by a previous failed attempt.
                         "error": None,
+                        # Written here as well as on the requeue, because the
+                        # requeue write is guarded and can be skipped during
+                        # the very outage being retried through. Without this a
+                        # task that recovered would report zero retries.
+                        "retry_count": attempt - 1,
                     },
                 )
 

--- a/app/services/whisperx_wrapper_service.py
+++ b/app/services/whisperx_wrapper_service.py
@@ -444,6 +444,11 @@ def process_audio_common(
                         "end_time": end_time,
                         # Clear any error recorded by a previous failed attempt.
                         "error": None,
+                        # Written here as well as on the requeue, because the
+                        # requeue write is guarded and can be skipped during
+                        # the very outage being retried through. Without this a
+                        # task that recovered would report zero retries.
+                        "retry_count": attempt - 1,
                     },
                 )
 

--- a/tests/unit/services/test_process_audio_task_retry.py
+++ b/tests/unit/services/test_process_audio_task_retry.py
@@ -249,3 +249,37 @@ def test_retry_survives_a_failed_requeue_write() -> None:
     # The retry still happened despite the requeue write blowing up.
     assert processor.call_count == 2
     assert harness.final_update()["status"] == TaskStatus.completed
+
+
+@pytest.mark.unit
+def test_completed_task_records_the_retries_it_actually_used() -> None:
+    """A task that succeeds on a retry must store how many retries it took.
+
+    The requeue write is deliberately guarded, so it can be skipped entirely
+    during the outage being retried through. When that happens nothing else
+    records the count, and a task that recovered on its second attempt would
+    report ``retry_count`` 0 -- indistinguishable from one that never failed.
+    """
+    harness = _Harness()
+    processor = MagicMock(
+        side_effect=[InsufficientMemoryError("transcription"), {"text": "ok"}]
+    )
+
+    _run(harness, processor, max_retries="2", fail_update_on=TaskStatus.queued)
+
+    final = harness.final_update()
+    assert final["status"] == TaskStatus.completed
+    # One retry was used: the second attempt. The failed requeue write must not
+    # be the only place that fact is recorded.
+    assert final["retry_count"] == 1
+
+
+@pytest.mark.unit
+def test_first_attempt_success_records_no_retries() -> None:
+    """A task that never failed reports zero retries, not a stale count."""
+    harness = _Harness()
+    processor = MagicMock(return_value={"text": "ok"})
+
+    _run(harness, processor, max_retries="2")
+
+    assert harness.final_update()["retry_count"] == 0


### PR DESCRIPTION
# Pull Request

## Description

Found by Copilot on the release PR #574. The finding is real, though not for the reason given — worth writing down, because the reasoning is what locates the actual bug.

`attempt` is 1-based: attempt 1 is the original try, attempts 2..N are retries. So *retries made* after k attempts is `k - 1`. Tracing every write of `retry_count`:

| Path | Writes | Retries actually made | Correct? |
| --- | --- | --- | --- |
| Requeue after attempt N | `N` | `N - 1` | reads one high, transiently |
| Terminal failure at attempt N | `N - 1` | `N - 1` | ✅ |
| Terminal success at attempt N | *nothing* — last value is the requeue's `N - 1` | `N - 1` | ✅ *by luck* |

So in normal operation both terminal states already land on the right number. Copilot's stated reason — that the value "can remain stale" on success — does not hold: the requeue write left exactly the right value behind.

**But that is only true while the requeue write actually happens, and it is deliberately guarded:**

```python
# DatabaseOperationError is itself retryable — so the very outage being
# retried through can break it. Letting it escape would kill the retry loop
# at the moment it is most needed.
try:
    repository.update(..., {"status": TaskStatus.queued, "retry_count": attempt})
except Exception:  # noqa: BLE001
    logger.warning("Could not record the requeue ...")
```

When that guard fires, nothing else records the retry. A task that failed once and recovered on its second attempt reports `retry_count` **0** — indistinguishable from one that never failed. The terminal *failure* path is immune because it writes `attempt - 1` itself; only the *completion* path was silent.

The guard added for resilience is what opened the hole. Copilot's suggested remedy is right; its diagnosis pointed elsewhere.

## The change

`"retry_count": attempt - 1` on the completion write, in both runners (`audio_processing_service.py`, `whisperx_wrapper_service.py`).

In the normal path this is a **no-op** — it writes the value the requeue already stored. It differs only when the guarded write was skipped, which is precisely the case that was losing the count.

### Deliberately not changed

The requeue write still stores `attempt` rather than `attempt - 1`, so `retry_count` reads one high while a task sits `queued` — it names the retry about to run rather than retries completed. That is transient, invisible in both terminal states, and now bracketed by two writes that agree. Correcting it would churn existing test expectations for no behavioural gain, so it stays as-is.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation — the docstring ("number of retry attempts made") already described the intended behaviour; this makes the code match it
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Tests

Written first, confirmed failing with `KeyError: 'retry_count'` against the unpatched runner:

- `test_completed_task_records_the_retries_it_actually_used` — drives the exact hole: `fail_update_on=TaskStatus.queued` makes the guarded requeue write raise, the second attempt succeeds, and the completed task must still report `retry_count == 1`.
- `test_first_attempt_success_records_no_retries` — pins the other end, so the new write cannot start inventing retries that never happened.

## Verification

- `pytest tests/unit/services/test_process_audio_task_retry.py test_process_audio_common_retry.py test_retry.py` → **43 passed**
- `pytest -m "not load"` → **519 passed, 8 failed, 38 skipped**
- `ruff check` clean, `ruff format --check` clean (172 files), `mypy app/` clean (87 files)

The 8 failures are pre-existing and unrelated: `401 Cannot access gated repo` for `pyannote/speaker-diarization-community-1`, because there is no `HF_TOKEN` in this container. They fail identically on `dev` without this change.

## Additional context

Targets `dev`, so the release PR #574 picks it up once merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfk9AG4pWLm4LutyGagUoj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Completed audio-processing tasks now accurately retain the number of retry attempts used.
  * Tasks that succeed on their first attempt correctly record zero retries.
  * Retry information remains accurate even when requeue tracking encounters an issue.

* **Tests**
  * Added coverage for retry metadata on recovered and first-attempt successes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->