### PR TITLE
fix: redact percent-encoded query params and route OTLP signals correctly

### DIFF
--- a/app/api/middleware.py
+++ b/app/api/middleware.py
@@ -4,6 +4,7 @@ import logging
 import time
 from collections.abc import Iterable, MutableMapping
 from typing import Any
+from urllib.parse import unquote_plus
 
 from starlette.responses import JSONResponse
 from starlette.types import ASGIApp, Receive, Scope, Send
@@ -103,7 +104,10 @@ def _sanitize_query_string(raw_query: bytes, sensitive: set[str]) -> str:
     sanitized = []
     for pair in decoded.split("&"):
         name, separator, _ = pair.partition("=")
-        if separator and name.lower() in sensitive:
+        # Decoded before matching: query parsers resolve percent-escapes, so
+        # "to%6ben" names the same parameter as "token" and carries the same
+        # credential. Comparing the raw spelling would let it through.
+        if separator and unquote_plus(name).lower() in sensitive:
             sanitized.append(f"{name}={_REDACTED}")
         else:
             sanitized.append(pair)

--- a/app/observability/metrics.py
+++ b/app/observability/metrics.py
@@ -13,7 +13,7 @@ from opentelemetry.sdk.metrics import MeterProvider
 from opentelemetry.sdk.metrics.export import PeriodicExportingMetricReader
 
 from app.core.config import Settings
-from app.observability.tracing import build_resource
+from app.observability.tracing import _signal_endpoint, build_resource
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +33,9 @@ def configure_metrics(settings: Settings) -> MeterProvider | None:
     # As in tracing: an empty endpoint defers to the SDK's own env var.
     endpoint = settings.observability.EXPORTER_ENDPOINT
     exporter = (
-        OTLPMetricExporter(endpoint=endpoint) if endpoint else OTLPMetricExporter()
+        OTLPMetricExporter(endpoint=_signal_endpoint(endpoint, "metrics"))
+        if endpoint
+        else OTLPMetricExporter()
     )
     reader = PeriodicExportingMetricReader(
         exporter,

--- a/app/observability/tracing.py
+++ b/app/observability/tracing.py
@@ -6,6 +6,7 @@ state, so the application keeps behaving exactly as it did before.
 
 import logging
 from importlib.metadata import PackageNotFoundError, version
+from urllib.parse import urlsplit
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -17,6 +18,35 @@ from opentelemetry.sdk.trace.sampling import ParentBasedTraceIdRatio
 from app.core.config import Settings
 
 logger = logging.getLogger(__name__)
+
+
+def _signal_endpoint(endpoint: str, signal: str) -> str:
+    """Resolve an OTLP/HTTP endpoint to its signal-specific URL.
+
+    An explicit ``endpoint=`` is sent verbatim by the exporters, unlike the
+    SDK's own ``OTEL_EXPORTER_OTLP_ENDPOINT``, which is treated as a base and
+    gets the signal path appended. Configuring a bare collector URL — which is
+    what the documentation asks for — would therefore POST both traces and
+    metrics to the collector root, where they are dropped.
+
+    A URL that already carries a path is left untouched: that is the operator
+    naming a specific ingest route, and second-guessing it would break gateways
+    that do not use the conventional layout.
+
+    Args:
+        endpoint: The configured OTLP/HTTP endpoint. Assumed non-empty.
+        signal: The OTLP signal name, ``traces`` or ``metrics``.
+
+    Returns:
+        The endpoint the exporter should post to.
+    """
+    base = endpoint.rstrip("/")
+    path = urlsplit(base).path
+
+    if path:
+        return endpoint
+
+    return f"{base}/v1/{signal}"
 
 
 def _service_version() -> str:
@@ -65,7 +95,11 @@ def configure_tracing(settings: Settings) -> TracerProvider | None:
     # An empty endpoint is deliberate — the exporter then reads the SDK's own
     # OTEL_EXPORTER_OTLP_ENDPOINT, so existing collector config keeps working.
     endpoint = settings.observability.EXPORTER_ENDPOINT
-    exporter = OTLPSpanExporter(endpoint=endpoint) if endpoint else OTLPSpanExporter()
+    exporter = (
+        OTLPSpanExporter(endpoint=_signal_endpoint(endpoint, "traces"))
+        if endpoint
+        else OTLPSpanExporter()
+    )
     provider.add_span_processor(BatchSpanProcessor(exporter))
 
     trace.set_tracer_provider(provider)

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -11,6 +11,10 @@ OTEL__ENABLED=true
 OTEL__EXPORTER_ENDPOINT=http://collector:4318   # OTLP/HTTP base endpoint
 ```
 
+A base URL is what you want here: the signal path is appended for you, so traces go to
+`/v1/traces` and metrics to `/v1/metrics`. Setting a URL that already has a path — a
+gateway with its own ingest route, say — disables that and the value is used verbatim.
+
 Leaving `OTEL__EXPORTER_ENDPOINT` empty is supported and useful: the exporters then fall
 back to the SDK's own standard variables (`OTEL_EXPORTER_OTLP_ENDPOINT`,
 `OTEL_EXPORTER_OTLP_HEADERS`, …), so an existing collector setup keeps working untouched.

--- a/tests/unit/api/test_timing_logging_middleware.py
+++ b/tests/unit/api/test_timing_logging_middleware.py
@@ -13,6 +13,7 @@ from app.api.middleware import (
     RequestLoggingMiddleware,
     TimingMiddleware,
     _sanitize_headers,
+    _REDACTED,
     _sanitize_query_string,
 )
 from app.core.config import get_settings
@@ -276,3 +277,33 @@ def test_sanitize_query_string_handles_empty_and_valueless() -> None:
     assert _sanitize_query_string(b"flag&token=x", {"token"}) == (
         "flag&token=***REDACTED***"
     )
+
+
+@pytest.mark.unit
+def test_sanitize_query_string_redacts_percent_encoded_names() -> None:
+    """A percent-encoded parameter name must not slip past the redaction set.
+
+    ``to%6ben`` is decoded to ``token`` by every real query parser, so a
+    credential sent under that spelling is just as sensitive as one sent
+    plainly -- but a raw string comparison does not match it.
+    """
+    result = _sanitize_query_string(b"to%6ben=super-secret", {"token"})
+
+    assert "super-secret" not in result
+    assert _REDACTED in result
+
+
+@pytest.mark.unit
+def test_sanitize_query_string_preserves_the_encoded_name() -> None:
+    """Redaction replaces the value only; the name is logged as it arrived."""
+    result = _sanitize_query_string(b"to%6ben=super-secret", {"token"})
+
+    assert result == f"to%6ben={_REDACTED}"
+
+
+@pytest.mark.unit
+def test_sanitize_query_string_decodes_plus_as_space() -> None:
+    """``+`` is a space in query strings, so it must decode before matching."""
+    result = _sanitize_query_string(b"api+key=super-secret", {"api key"})
+
+    assert "super-secret" not in result

--- a/tests/unit/observability/test_observability.py
+++ b/tests/unit/observability/test_observability.py
@@ -13,7 +13,11 @@ from opentelemetry.sdk.trace import TracerProvider
 import app.observability as observability
 from app.core.config import Settings, get_settings
 from app.observability.metrics import configure_metrics
-from app.observability.tracing import build_resource, configure_tracing
+from app.observability.tracing import (
+    _signal_endpoint,
+    build_resource,
+    configure_tracing,
+)
 
 _ENV_KEYS = (
     "OTEL__ENABLED",
@@ -193,3 +197,45 @@ def test_configure_observability_reads_cached_settings_when_omitted() -> None:
     observability.configure_observability(app)
 
     assert observability._tracer_provider is None
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("http://collector:4318", "http://collector:4318/v1/traces"),
+        ("http://collector:4318/", "http://collector:4318/v1/traces"),
+        # An explicit path is the operator's choice and is left alone.
+        ("http://collector:4318/v1/traces", "http://collector:4318/v1/traces"),
+        ("http://gateway/custom/ingest", "http://gateway/custom/ingest"),
+    ],
+)
+def test_traces_endpoint_gets_the_signal_path(configured: str, expected: str) -> None:
+    """A bare collector URL must reach /v1/traces, not the collector root.
+
+    The exporter uses an explicit ``endpoint`` verbatim, so a base URL -- which
+    is exactly what the documentation tells operators to configure -- would
+    otherwise POST spans to the collector root and be dropped.
+    """
+    assert _signal_endpoint(configured, "traces") == expected
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        ("http://collector:4318", "http://collector:4318/v1/metrics"),
+        ("http://collector:4318/v1/metrics", "http://collector:4318/v1/metrics"),
+    ],
+)
+def test_metrics_endpoint_gets_the_signal_path(configured: str, expected: str) -> None:
+    """Metrics resolve to their own path, not the same URL as traces."""
+    assert _signal_endpoint(configured, "metrics") == expected
+
+
+@pytest.mark.unit
+def test_traces_and_metrics_do_not_share_one_endpoint() -> None:
+    """One configured base must fan out to two distinct signal endpoints."""
+    base = "http://collector:4318"
+
+    assert _signal_endpoint(base, "traces") != _signal_endpoint(base, "metrics")


### PR DESCRIPTION
# Pull Request

## Description

Two Major findings from CodeRabbit's review of the release PR #574. Both verified by running the code rather than by reading it, both real, both small.

The other four findings from that review are addressed on #574 itself — two declined with evidence, two raised as issues. Summary at the bottom.

## 1 — Credentials survived redaction when the parameter name was percent-encoded

`_sanitize_query_string` did `raw_query.decode("latin-1")`. That is a bytes→str decode, **not** percent-decoding, and the raw name was then compared against the sensitive set. Every real query parser resolves percent-escapes first, so the two disagree:

```
$ _sanitize_query_string(b"token=super-secret",   {"token"})   -> token=***REDACTED***
$ _sanitize_query_string(b"to%6ben=super-secret", {"token"})   -> to%6ben=super-secret   ← leaked
$ parse_qs("to%6ben=super-secret").keys()                      -> ['token']
```

`%6b` is `k`, so `to%6ben` **is** `token` to the application — and the secret went to the log in full.

**Fixed** by decoding the name before matching. The original spelling is preserved in the output so the shape of the request stays readable; only the value is replaced. `unquote_plus` rather than `unquote`, because `+` is a space in a query string and can appear in a name too.

Blast radius is limited — `RequestLoggingMiddleware` is off by default — but the deployments that turned it on are exactly the ones writing the log.

## 2 — Both OTLP signals posted to the collector root, on the same URL

The exporters treat an explicit `endpoint=` as a complete URL and use it verbatim. This is *not* the behaviour of the SDK's own `OTEL_EXPORTER_OTLP_ENDPOINT`, which is a base and gets the signal path appended — an easy pair to conflate. Checked against the pinned version rather than assumed:

```
opentelemetry-exporter-otlp-proto-http 1.40.0

OTLPSpanExporter(endpoint="http://collector:4318")._endpoint
  -> http://collector:4318                    # no /v1/traces
OTLPMetricExporter(endpoint="http://collector:4318")._endpoint
  -> http://collector:4318                    # same URL, no /v1/metrics
```

And `docs/observability/README.md` told operators to configure exactly that:

```bash
OTEL__EXPORTER_ENDPOINT=http://collector:4318   # OTLP/HTTP base endpoint
```

So following our own documentation sent traces and metrics to the same pathless URL, where the collector drops them. Telemetry would simply never arrive, with nothing in the application to indicate why.

**Fixed** by appending `/v1/traces` and `/v1/metrics` when the configured endpoint carries no path. An endpoint that already has one is left untouched — that is an operator naming a specific ingest route, and rewriting it would break gateways that do not use the conventional layout. An empty endpoint still defers to the SDK variables, unchanged.

Confirmed on the real exporters after the fix:

```
traces  -> http://collector:4318/v1/traces
metrics -> http://collector:4318/v1/metrics
```

Docs updated to say which behaviour applies when.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Documentation update
- [ ] Other

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

## Tests

Written first, confirmed failing against the unpatched code:

- `test_sanitize_query_string_redacts_percent_encoded_names` — the exact bypass
- `test_sanitize_query_string_preserves_the_encoded_name` — pins that only the value changes
- `test_sanitize_query_string_decodes_plus_as_space` — `+` is a space, not a literal
- `test_traces_endpoint_gets_the_signal_path` / `test_metrics_endpoint_gets_the_signal_path` — parametrised over bare, trailing-slash, already-pathed, and custom-gateway URLs
- `test_traces_and_metrics_do_not_share_one_endpoint` — pins the "same URL for both signals" failure directly

## Verification

- `pytest -m "not load"` → **529 passed**, 8 failed, 38 skipped (was 519 passed before these 10 tests)
- `ruff check .` clean, `ruff format --check` clean (176 files), `mypy app/` clean (87 files)

The 8 failures are pre-existing and unrelated: `401 Cannot access gated repo` for `pyannote/speaker-diarization-community-1`, no `HF_TOKEN` in this container. Identical on `dev` without this change.

## Additional context

The remaining four findings from the same review, handled on #574:

| Finding | Disposition |
| --- | --- |
| `_is_legacy_database()` validates tables but not columns | **Real** — raised as an issue. Heavy lift, and it is the one-time legacy-adoption path, not the normal one |
| Migrations not serialised across instances | **Real for replicas** — raised as an issue. The shipped image runs `--workers 1`, so the default config does not race |
| Ruff `BLE001` on the outer `except Exception` handlers | **Declined** — `uv run ruff check .` passes clean; `BLE001` is not in this repo's selected rules. It only fires under `--select BLE001`, which is what the reviewer ran |
| `docs/observability/README.md` needs `post_title` / `microsoft_alias` front matter | **Declined** — the convention comes from a stray boilerplate instruction file. **0 of 34** markdown files in the repo conform, including `README.md` and `CLAUDE.md`, and it references a `categories.txt` that does not exist |

Targets `dev`, so #574 picks both fixes up once merged.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfk9AG4pWLm4LutyGagUoj)_