### PR TITLE
fix(observability): build the OTLP signal path as a URL component

### DIFF
--- a/app/observability/tracing.py
+++ b/app/observability/tracing.py
@@ -6,7 +6,7 @@ state, so the application keeps behaving exactly as it did before.
 
 import logging
 from importlib.metadata import PackageNotFoundError, version
-from urllib.parse import urlsplit
+from urllib.parse import urlsplit, urlunsplit
 
 from opentelemetry import trace
 from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
@@ -40,13 +40,18 @@ def _signal_endpoint(endpoint: str, signal: str) -> str:
     Returns:
         The endpoint the exporter should post to.
     """
-    base = endpoint.rstrip("/")
-    path = urlsplit(base).path
+    parts = urlsplit(endpoint)
 
-    if path:
+    # Only the path component decides. A lone "/" is the collector root, not a
+    # route the operator chose, so it still gets the signal path.
+    if parts.path.strip("/"):
         return endpoint
 
-    return f"{base}/v1/{signal}"
+    # Rebuilt from the parsed parts rather than concatenated, so the path lands
+    # ahead of any query or fragment. Appending textually to a URL like
+    # "http://collector:4318?tenant=foo" would bury "/v1/traces" inside the
+    # query value and post to the collector root.
+    return urlunsplit(parts._replace(path=f"/v1/{signal}"))
 
 
 def _service_version() -> str:

--- a/tests/unit/observability/test_observability.py
+++ b/tests/unit/observability/test_observability.py
@@ -239,3 +239,40 @@ def test_traces_and_metrics_do_not_share_one_endpoint() -> None:
     base = "http://collector:4318"
 
     assert _signal_endpoint(base, "traces") != _signal_endpoint(base, "metrics")
+
+
+@pytest.mark.unit
+@pytest.mark.parametrize(
+    ("configured", "expected"),
+    [
+        (
+            "http://collector:4318?tenant=foo",
+            "http://collector:4318/v1/traces?tenant=foo",
+        ),
+        (
+            "http://collector:4318/?tenant=foo",
+            "http://collector:4318/v1/traces?tenant=foo",
+        ),
+        ("http://collector:4318#frag", "http://collector:4318/v1/traces#frag"),
+        (
+            "http://collector:4318/?tenant=foo#frag",
+            "http://collector:4318/v1/traces?tenant=foo#frag",
+        ),
+        # A real path still wins, and its query rides along untouched.
+        (
+            "http://gateway/custom/ingest?tenant=foo",
+            "http://gateway/custom/ingest?tenant=foo",
+        ),
+    ],
+)
+def test_signal_path_is_inserted_before_query_and_fragment(
+    configured: str, expected: str
+) -> None:
+    """The signal path belongs in the path component, not glued onto the end.
+
+    A collector URL carrying a query string -- a tenant selector on a
+    multi-tenant gateway, say -- has no path, so it needs the signal path.
+    Appending it textually would produce ``...:4318?tenant=foo/v1/traces``,
+    burying the path inside the query value and sending spans nowhere.
+    """
+    assert _signal_endpoint(configured, "traces") == expected


### PR DESCRIPTION
# Pull Request

## Description

Follow-up to #576, fixing a defect in the `_signal_endpoint` helper that PR introduced. Found by CodeRabbit's re-review on #574 and confirmed by running the helper directly.

`_signal_endpoint` appended `/v1/<signal>` as **text**, so an endpoint carrying a query string or fragment had the path glued on after it:

```
http://collector:4318?tenant=foo  ->  http://collector:4318?tenant=foo/v1/traces
http://collector:4318#frag        ->  http://collector:4318#frag/v1/traces
```

The signal path ends up buried inside the query value, so the exporter posts to the collector root and the spans and metrics are dropped — silently, which is the same failure mode #576 set out to fix.

A second case, not in the original report but found while verifying it: the helper treated a lone `/` as an operator-chosen ingest route, because `urlsplit("http://collector:4318/?tenant=foo").path` is `"/"` and therefore truthy. That URL was returned verbatim and never reached `/v1/traces` at all.

The fix rebuilds the URL from its parsed components with `urlunsplit`, so the path lands in the path slot ahead of any query or fragment, and decides whether a path was configured only after stripping slashes, so the collector root is recognised as the root.

Behaviour for every previously-working input is unchanged:

| Configured | Before | After |
| --- | --- | --- |
| `http://collector:4318` | `…/v1/traces` | `…/v1/traces` |
| `http://collector:4318/` | `…/v1/traces` | `…/v1/traces` |
| `http://collector:4318?tenant=foo` | `…?tenant=foo/v1/traces` ❌ | `…/v1/traces?tenant=foo` ✅ |
| `http://collector:4318/?tenant=foo` | `…/?tenant=foo` ❌ | `…/v1/traces?tenant=foo` ✅ |
| `http://collector:4318#frag` | `…#frag/v1/traces` ❌ | `…/v1/traces#frag` ✅ |
| `http://collector:4318/ingest` | verbatim | verbatim |
| `http://gateway/custom/ingest?tenant=foo` | verbatim | verbatim |

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Documentation needed no change: `docs/observability/README.md` already states that a base URL gets the signal path appended and that a URL with its own path is used verbatim. That contract was correct — the implementation did not honour it for URLs with a query or fragment.

## Additional context

Written test-first, per the repo's TDD workflow: the five new parametrised cases in `tests/unit/observability/test_observability.py` were added and run against the old implementation first, where four failed with exactly the concatenation shown above. They pass after the change.

Validation run locally:

- `ruff check .` — all checks passed
- `ruff format --check .` — 176 files already formatted
- `mypy app/` — success, no issues in 87 source files
- `pytest -m "not load"` — 534 passed, 89% coverage

Eight e2e tests fail in this container with an HF `401 Client Error`, because `HF_TOKEN` is not set here and they exercise diarization model downloads. They are unrelated to this change and pass in CI, which has the token.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Pfk9AG4pWLm4LutyGagUoj)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved observability endpoint handling for collector URLs.
  * Signal-specific paths are now inserted correctly before query strings and fragments.
  * Preserved explicitly configured endpoint paths and URL components.

* **Tests**
  * Added coverage for URLs containing query parameters, fragments, and custom paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->